### PR TITLE
Select KeyInfo node instead of parent's first child

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/IdPSsoDescriptor.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/IdPSsoDescriptor.cs
@@ -115,7 +115,7 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
         {
             foreach (XmlElement keyDescriptorElement in keyDescriptorElements)
             {
-                var keyInfoElement = keyDescriptorElement.FirstChild as XmlElement;
+                var keyInfoElement = keyDescriptorElement.SelectSingleNode($"*[local-name()='{Saml2MetadataConstants.Message.KeyInfo}']") as XmlElement;
                 if (keyInfoElement != null)
                 {
                     var keyInfo = new KeyInfo();

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/Saml2MetadataConstants.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/Saml2MetadataConstants.cs
@@ -53,6 +53,8 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
 
             public const string Use = "use";
 
+            public const string KeyInfo = "KeyInfo";
+
             public const string SingleLogoutService = "SingleLogoutService";
 
             public const string SingleSignOnService = "SingleSignOnService";            


### PR DESCRIPTION
Reading key descriptor elements fails, if there is some white-space between the elements. Selecting the target element explicitly instead of just checking the parent's first child avoids that.
