### PR TITLE
Add ValidateSignature to Saml2Configuration.

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Bindings/Saml2PostBinding.cs
+++ b/src/ITfoxtec.Identity.Saml2/Bindings/Saml2PostBinding.cs
@@ -98,7 +98,7 @@ namespace ITfoxtec.Identity.Saml2
                 RelayState = request.Form[Saml2Constants.Message.RelayState];
             }
 
-            return Read(request, saml2RequestResponse, messageName, true);
+            return Read(request, saml2RequestResponse, messageName, saml2RequestResponse.Config.ValidateSignature);
         }
 
         protected override Saml2Request Read(HttpRequest request, Saml2Request saml2RequestResponse, string messageName, bool validateXmlSignature)

--- a/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
+++ b/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
@@ -32,5 +32,7 @@ namespace ITfoxtec.Identity.Saml2
         public List<Uri> AllowedAudienceUris { get; protected set; } = new List<Uri>();
 
         public bool SignAuthnRequest { get; set; } = false;
+
+        public bool ValidateSignature { get; set; }
     }
 }

--- a/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
+++ b/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
@@ -33,6 +33,6 @@ namespace ITfoxtec.Identity.Saml2
 
         public bool SignAuthnRequest { get; set; } = false;
 
-        public bool ValidateSignature { get; set; }
+        public bool ValidateSignature { get; set; } = true;
     }
 }

--- a/src/ITfoxtec.Identity.Saml2/Util/GenericTypeConverter.cs
+++ b/src/ITfoxtec.Identity.Saml2/Util/GenericTypeConverter.cs
@@ -18,7 +18,7 @@ namespace ITfoxtec.Identity.Saml2.Util
             var genericType = typeof(T);
             if (genericType == typeof(Uri))
             {
-                return GenericConvertValue<T, Uri>(new Uri(value));
+                return GenericConvertValue<T, Uri>(new Uri(value, UriKind.RelativeOrAbsolute));
             }
             if (genericType == typeof(Saml2Id))
             {


### PR DESCRIPTION
Only validate the signature of Saml2Responses if the value of "ValidateSignature" in configuration is true.
Generate new URIs as RelativeOrAbsolute to prevent Exceptions.