### PR TITLE
Add CustomCertificateValidator property to Saml2Configuration

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
+++ b/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
@@ -1,6 +1,7 @@
 ﻿using ITfoxtec.Identity.Saml2.Schemas;
 using System;
 using System.Collections.Generic;
+using System.IdentityModel.Selectors;
 using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel.Security;
 
@@ -25,6 +26,7 @@ namespace ITfoxtec.Identity.Saml2
         public List<X509Certificate2> SignatureValidationCertificates { get; protected set; } = new List<X509Certificate2>();
         public X509CertificateValidationMode CertificateValidationMode { get; set; } = X509CertificateValidationMode.ChainTrust;
         public X509RevocationMode RevocationMode { get; set; } = X509RevocationMode.Online;
+        public X509CertificateValidator CustomCertificateValidator { get; set; }
 
         public bool SaveBootstrapContext { get; set; } = false;
 

--- a/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
+++ b/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
@@ -1,9 +1,11 @@
 ﻿using ITfoxtec.Identity.Saml2.Schemas;
 using System;
 using System.Collections.Generic;
-using System.IdentityModel.Selectors;
 using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel.Security;
+#if !NETFULL
+using System.IdentityModel.Selectors;
+#endif
 
 namespace ITfoxtec.Identity.Saml2
 {
@@ -26,7 +28,9 @@ namespace ITfoxtec.Identity.Saml2
         public List<X509Certificate2> SignatureValidationCertificates { get; protected set; } = new List<X509Certificate2>();
         public X509CertificateValidationMode CertificateValidationMode { get; set; } = X509CertificateValidationMode.ChainTrust;
         public X509RevocationMode RevocationMode { get; set; } = X509RevocationMode.Online;
+#if !NETFULL
         public X509CertificateValidator CustomCertificateValidator { get; set; }
+#endif
 
         public bool SaveBootstrapContext { get; set; } = false;
 

--- a/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
+++ b/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
@@ -3,9 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel.Security;
-#if !NETFULL
 using System.IdentityModel.Selectors;
-#endif
 
 namespace ITfoxtec.Identity.Saml2
 {
@@ -28,9 +26,7 @@ namespace ITfoxtec.Identity.Saml2
         public List<X509Certificate2> SignatureValidationCertificates { get; protected set; } = new List<X509Certificate2>();
         public X509CertificateValidationMode CertificateValidationMode { get; set; } = X509CertificateValidationMode.ChainTrust;
         public X509RevocationMode RevocationMode { get; set; } = X509RevocationMode.Online;
-#if !NETFULL
         public X509CertificateValidator CustomCertificateValidator { get; set; }
-#endif
 
         public bool SaveBootstrapContext { get; set; } = false;
 

--- a/src/ITfoxtec.Identity.Saml2/Configuration/Saml2IdentityConfiguration.cs
+++ b/src/ITfoxtec.Identity.Saml2/Configuration/Saml2IdentityConfiguration.cs
@@ -1,13 +1,13 @@
-﻿using System.Security.Cryptography.X509Certificates;
-using ITfoxtec.Identity.Saml2.Util;
+﻿using System;
+using System.ServiceModel.Security;
 #if NETFULL
 using ITfoxtec.Identity.Saml2.Tokens;
-using System;
 using System.Collections.Generic;
 using System.IdentityModel.Configuration;
 using System.IdentityModel.Tokens;
 #else
 using System.Linq;
+using ITfoxtec.Identity.Saml2.Util;
 using Microsoft.IdentityModel.Tokens;
 using System.Security.Claims;
 using System.IdentityModel.Selectors;
@@ -54,7 +54,23 @@ namespace ITfoxtec.Identity.Saml2.Configuration
                 RevocationMode = config.RevocationMode,
             };
 #endif
+
+            SetCustomCertificateValidator(configuration, config);
+
             return configuration;
+        }
+
+        private static void SetCustomCertificateValidator(Saml2IdentityConfiguration configuration, Saml2Configuration config)
+        {
+            if (config.CertificateValidationMode == X509CertificateValidationMode.Custom)
+            {
+                if (config.CustomCertificateValidator is null)
+                {
+                    throw new NotImplementedException("A CustomCertificateValidator is required when setting CertificateValidationMode = X509CertificateValidationMode.Custom");
+                }
+
+                configuration.CertificateValidator = config.CustomCertificateValidator;
+            }
         }
 
 #if NETFULL


### PR DESCRIPTION
Allow a custom certificate validator to be used to Saml2Configuration when CertificateValidationMode set to Custom