### PR TITLE
Allow a certain amount of 'give' in clock-based checks

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Bindings/Saml2PostBinding.cs
+++ b/src/ITfoxtec.Identity.Saml2/Bindings/Saml2PostBinding.cs
@@ -19,6 +19,12 @@ namespace ITfoxtec.Identity.Saml2
         public X509IncludeOption CertificateIncludeOption { get; set; }
 
         /// <summary>
+        /// [Optional]
+        /// Allow for clock slip of this amount (on top of what the IDP already includes in the NotOnOrAfter assertion)
+        /// </summary>
+        public TimeSpan? ClockTolerance { get; set; }
+
+        /// <summary>
         /// Html post content.
         /// </summary>
         public string PostContent { get; set; }
@@ -119,7 +125,7 @@ namespace ITfoxtec.Identity.Saml2
                 RelayState = request.Form[Saml2Constants.Message.RelayState];
             }
 
-            saml2RequestResponse.Read(Encoding.UTF8.GetString(Convert.FromBase64String(request.Form[messageName])), validateXmlSignature);
+            saml2RequestResponse.Read(Encoding.UTF8.GetString(Convert.FromBase64String(request.Form[messageName])), validateXmlSignature, this.ClockTolerance);
             XmlDocument = saml2RequestResponse.XmlDocument;
             return saml2RequestResponse;
         }

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnRequest.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnRequest.cs
@@ -126,7 +126,7 @@ namespace ITfoxtec.Identity.Saml2
             }
         }
 
-        protected internal override void Read(string xml, bool validateXmlSignature = false)
+        protected internal override void Read(string xml, bool validateXmlSignature = false, TimeSpan? clockTolerance = null)
         {
             base.Read(xml, validateXmlSignature);
 

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2LogoutRequest.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2LogoutRequest.cs
@@ -113,7 +113,7 @@ namespace ITfoxtec.Identity.Saml2
             }
         }
 
-        protected internal override void Read(string xml, bool validateXmlSignature = false)
+        protected internal override void Read(string xml, bool validateXmlSignature = false, TimeSpan? clockTolerance = null)
         {
             base.Read(xml, validateXmlSignature);
 

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2LogoutResponse.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2LogoutResponse.cs
@@ -43,7 +43,7 @@ namespace ITfoxtec.Identity.Saml2
             return XmlDocument;
         }
 
-        protected internal override void Read(string xml, bool validateXmlSignature = false)
+        protected internal override void Read(string xml, bool validateXmlSignature = false, TimeSpan? clockTolerance = null)
         {
             base.Read(xml, validateXmlSignature);
 

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
@@ -162,7 +162,7 @@ namespace ITfoxtec.Identity.Saml2
 
         public abstract XmlDocument ToXml();
 
-        protected internal virtual void Read(string xml, bool validateXmlSignature)
+        protected internal virtual void Read(string xml, bool validateXmlSignature = false, TimeSpan? clockTolerance = null)
         {
 #if DEBUG
             Debug.WriteLine("Saml2P: " + xml);

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2Response.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2Response.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Xml;
 using System.Xml.Linq;
 using ITfoxtec.Identity.Saml2.Util;
@@ -61,7 +62,7 @@ namespace ITfoxtec.Identity.Saml2
             }
         }
 
-        protected internal override void Read(string xml, bool validateXmlSignature = false)
+        protected internal override void Read(string xml, bool validateXmlSignature = false, TimeSpan? clockTolerance = null)
         {
             base.Read(xml, validateXmlSignature);
 


### PR DESCRIPTION
Hi there,

-- Noted that I put this request on the old version, hoping you'll accept on the correct version :) --

We have some challenging government clients that are not inclined to make changes at the Identity Provider end to clock tolerance, so have provided the ability to add an additional tolerance to NotOnOrAfter checks.

I am not sure if this is the 'best' way but I thought it easier to illustrate my suggestion.

We have done this is in the past with a home-grown SAML2 implementation, but would prefer to use your lovely solution instead.

Comments and criticism welcome,

Thanks heaps,
Stuart