### PR TITLE
Add DateFormat do Saml2Configuration and respect it in the repository.

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
+++ b/src/ITfoxtec.Identity.Saml2/Configuration/Saml2Configuration.cs
@@ -68,5 +68,10 @@ namespace ITfoxtec.Identity.Saml2
         /// Sign type for the authn responses created by the library.
         /// </summary>
         public Saml2AuthnResponseSignTypes AuthnResponseSignType { get; set; } = Saml2AuthnResponseSignTypes.SignResponse;
+
+        /// <summary>
+        /// Format of the date. For compatibility reasons it is "o" by default
+        /// </summary>
+        public string DateFormat { get; set; } = "o";
     }
 }

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2LogoutRequest.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2LogoutRequest.cs
@@ -94,7 +94,7 @@ namespace ITfoxtec.Identity.Saml2
         {
             if (NotOnOrAfter.HasValue)
             {
-                yield return new XAttribute(Schemas.Saml2Constants.Message.NotOnOrAfter, NotOnOrAfter.Value.UtcDateTime.ToString("o", CultureInfo.InvariantCulture));
+                yield return new XAttribute(Schemas.Saml2Constants.Message.NotOnOrAfter, NotOnOrAfter.Value.UtcDateTime.ToString(Config.DateFormat, CultureInfo.InvariantCulture));
             }
 
             if (Reason != null)

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
@@ -137,7 +137,7 @@ namespace ITfoxtec.Identity.Saml2
             yield return new XAttribute(Schemas.Saml2Constants.AssertionNamespaceNameX, Schemas.Saml2Constants.AssertionNamespace.OriginalString);
             yield return new XAttribute(Schemas.Saml2Constants.Message.Id, IdAsString);
             yield return new XAttribute(Schemas.Saml2Constants.Message.Version, Version);
-            yield return new XAttribute(Schemas.Saml2Constants.Message.IssueInstant, IssueInstant.UtcDateTime.ToString("o", CultureInfo.InvariantCulture));
+            yield return new XAttribute(Schemas.Saml2Constants.Message.IssueInstant, IssueInstant.UtcDateTime.ToString(Config.DateFormat, CultureInfo.InvariantCulture));
 
             if (!string.IsNullOrWhiteSpace(Consent))
             {

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/EntityDescriptor.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/EntityDescriptor.cs
@@ -119,7 +119,7 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
             yield return new XAttribute(Saml2MetadataConstants.Message.Id, IdAsString);
             if (ValidUntil.HasValue)
             {
-                yield return new XAttribute(Saml2MetadataConstants.Message.ValidUntil, DateTimeOffset.UtcNow.AddDays(ValidUntil.Value).UtcDateTime.ToString("o", CultureInfo.InvariantCulture));
+                yield return new XAttribute(Saml2MetadataConstants.Message.ValidUntil, DateTimeOffset.UtcNow.AddDays(ValidUntil.Value).UtcDateTime.ToString(Config.DateFormat, CultureInfo.InvariantCulture));
             }
             yield return new XAttribute(Saml2MetadataConstants.MetadataNamespaceNameX, Saml2MetadataConstants.MetadataNamespace);
 


### PR DESCRIPTION
PR adds a possibility do define Date format. By default it is `"o"` as before. 

I needed this because current format was not acceptable by some IdentityProviders (e.g. Fortinet). I guess it could help others in such cases.