### PR TITLE
Support for saml2:conditions on AuthnRequest

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnRequest.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnRequest.cs
@@ -84,6 +84,13 @@ namespace ITfoxtec.Identity.Saml2
         /// </summary>
         public RequestedAuthnContext RequestedAuthnContext { get; set; }
 
+        /// <summary>
+        /// [Optional]
+        /// If present, specifies an Audience
+        /// Part of the OIOSAML standard used for conditions on request.
+        /// </summary>
+        public Condition Conditions { get; set; }
+
         public Saml2AuthnRequest(Saml2Configuration config) : base(config)
         {
             if (config == null) throw new ArgumentNullException(nameof(config));
@@ -122,6 +129,11 @@ namespace ITfoxtec.Identity.Saml2
             if (ProtocolBinding != null)
             {
                 yield return new XAttribute(Saml2Constants.Message.ProtocolBinding, ProtocolBinding);
+            }
+
+            if (Conditions != null)
+            {
+                yield return Conditions.ToXElement();
             }
 
             if (Subject != null)

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Xml;
 using System.Xml.Linq;
 using System.Security.Cryptography.Xml;
+using System.Diagnostics;
 #if NETFULL
 using System.IdentityModel.Tokens;
 #else
@@ -113,7 +114,7 @@ namespace ITfoxtec.Identity.Saml2
 
         internal Saml2IdentityConfiguration IdentityConfiguration { get; private set; }
 
-        public Saml2Request(Saml2Configuration config)
+        protected Saml2Request(Saml2Configuration config)
         {
             if (config == null) throw new ArgumentNullException(nameof(config));
 

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Condition.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Condition.cs
@@ -20,6 +20,8 @@ namespace ITfoxtec.Identity.Saml2.Schemas
 
         public DateTimeOffset? NotOnOrAfter { get; set; }
 
+        public DateTimeOffset? NotBefore { get; set; }
+
         public XElement ToXElement()
         {
             var envelope = new XElement(Saml2Constants.AssertionNamespaceX + elementName);
@@ -34,7 +36,16 @@ namespace ITfoxtec.Identity.Saml2.Schemas
             yield return new XAttribute(Saml2Constants.AssertionNamespaceNameX, Saml2Constants.AssertionNamespaceX);
             if (NotOnOrAfter.HasValue)
             {
-                yield return new XAttribute(Saml2Constants.Message.NotOnOrAfter, NotOnOrAfter.Value.UtcDateTime.ToString(Schemas.Saml2Constants.DateTimeFormat, CultureInfo.InvariantCulture))
+                yield return new XAttribute(Saml2Constants.Message.NotOnOrAfter,
+                    NotOnOrAfter.Value.UtcDateTime.ToString(Schemas.Saml2Constants.DateTimeFormat,
+                        CultureInfo.InvariantCulture));
+            }
+
+            if (NotBefore.HasValue)
+            {
+                yield return new XAttribute(Saml2Constants.Message.NotBefore,
+                    NotBefore.Value.UtcDateTime.ToString(Schemas.Saml2Constants.DateTimeFormat,
+                        CultureInfo.InvariantCulture));
             }
             if (Items != null)
             {

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Condition.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Condition.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Xml.Linq;
+using ITfoxtec.Identity.Saml2.Schemas.Conditions;
+
+namespace ITfoxtec.Identity.Saml2.Schemas
+{
+    /// <summary>
+    /// Implementation of Saml2:Condition
+    /// </summary>
+    public class Condition
+    {
+        /// <summary>
+        /// The XML Element name of this class
+        /// </summary>
+        public const string elementName = Saml2Constants.Message.Conditions;
+
+        public List<ConditionAbstract> Items { get; set; }
+
+        public DateTimeOffset? NotOnOrAfter { get; set; }
+
+        public XElement ToXElement()
+        {
+            var envelope = new XElement(Saml2Constants.AssertionNamespaceX + elementName);
+
+            envelope.Add(GetXContent());
+
+            return envelope;
+        }
+
+        protected virtual IEnumerable<XObject> GetXContent()
+        {
+            yield return new XAttribute(Saml2Constants.AssertionNamespaceNameX, Saml2Constants.AssertionNamespaceX);
+            if (NotOnOrAfter.HasValue)
+            {
+                yield return new XAttribute(Saml2Constants.Message.NotOnOrAfter, NotOnOrAfter.Value.UtcDateTime.ToString(Schemas.Saml2Constants.DateTimeFormat, CultureInfo.InvariantCulture))
+            }
+            if (Items != null)
+            {
+                foreach (var condition in Items)
+                {
+                    yield return condition.ToXElement();
+                }
+            }
+        }
+    }
+}

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Conditions/Audience.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Conditions/Audience.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace ITfoxtec.Identity.Saml2.Schemas.Conditions
+{
+    public class Audience
+    {
+        /// <summary>
+        /// The XML Element name of this class
+        /// </summary>
+        const string elementName = Saml2Constants.Message.Audience;
+
+        public string Uri { get; set; }
+
+        public XElement ToXElement()
+        {
+            var envelope = new XElement(Saml2Constants.AssertionNamespaceX + elementName);
+
+            envelope.Add(GetXContent());
+
+            return envelope;
+        }
+
+        protected IEnumerable<XObject> GetXContent()
+        {
+            if (!string.IsNullOrEmpty(Uri))
+            {
+                yield return new XText(Uri);
+            }
+        }
+    }
+}

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Conditions/AudienceRestriction.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Conditions/AudienceRestriction.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace ITfoxtec.Identity.Saml2.Schemas.Conditions
+{
+    public class AudienceRestriction : ConditionAbstract
+    {
+        /// <summary>
+        /// The XML Element name of this class
+        /// </summary>
+        const string elementName = Saml2Constants.Message.AudienceRestriction;
+
+        public List<Audience> Audiences { get; set; }
+
+        public override XElement ToXElement()
+        {
+            var envelope = new XElement(Saml2Constants.AssertionNamespaceX + elementName);
+
+            envelope.Add(GetXContent());
+
+            return envelope;
+        }
+
+        protected IEnumerable<XObject> GetXContent()
+        {
+            if (Audiences != null)
+            {
+                foreach (var audience in Audiences)
+                {
+                    yield return audience.ToXElement();
+                }
+            }
+        }
+    }
+}

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Conditions/ConditionAbstract.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Conditions/ConditionAbstract.cs
@@ -1,0 +1,9 @@
+﻿using System.Xml.Linq;
+
+namespace ITfoxtec.Identity.Saml2.Schemas.Conditions
+{
+    public abstract class ConditionAbstract
+    {
+        public abstract XElement ToXElement();
+    }
+}

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Conditions/OneTimeUse.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Conditions/OneTimeUse.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace ITfoxtec.Identity.Saml2.Schemas.Conditions
+{
+    public class OneTimeUse : ConditionAbstract
+    {
+        /// <summary>
+        /// The XML Element name of this class
+        /// </summary>
+        const string elementName = Saml2Constants.Message.OneTimeUse;
+
+        public override XElement ToXElement()
+        {
+            var envelope = new XElement(Saml2Constants.AssertionNamespaceX + elementName);
+
+            return envelope;
+        }
+    }
+}

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Conditions/ProxyRestriction.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Conditions/ProxyRestriction.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace ITfoxtec.Identity.Saml2.Schemas.Conditions
+{
+    public class ProxyRestriction : ConditionAbstract
+    {
+        /// <summary>
+        /// The XML Element name of this class
+        /// </summary>
+        const string elementName = Saml2Constants.Message.ProxyRestriction;
+
+        public List<Audience> Audiences { get; set; }
+
+        public uint? Count { get; set; }
+
+        public override XElement ToXElement()
+        {
+            var envelope = new XElement(Saml2Constants.AssertionNamespaceX + elementName);
+
+            envelope.Add(GetXContent());
+
+            return envelope;
+        }
+
+        protected IEnumerable<XObject> GetXContent()
+        {
+            if (Audiences != null)
+            {
+                foreach (var audience in Audiences)
+                {
+                    yield return audience.ToXElement();
+                }
+            }
+
+            if (Count.HasValue)
+            {
+                yield return new XAttribute(Saml2Constants.Message.Count, Count.Value);
+            }
+        }
+    }
+}

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Saml2Constants.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Saml2Constants.cs
@@ -119,6 +119,8 @@ namespace ITfoxtec.Identity.Saml2.Schemas
 
             internal const string NotOnOrAfter = "NotOnOrAfter";
 
+            internal const string NotBefore = "NotBefore";
+
             internal const string Reason = "Reason";
             
             internal const string NameIdPolicy = "NameIDPolicy";
@@ -142,6 +144,12 @@ namespace ITfoxtec.Identity.Saml2.Schemas
             internal const string SubjectConfirmation = "SubjectConfirmation";
 
             internal const string SubjectConfirmationData = "SubjectConfirmationData";
+
+            internal const string OneTimeUse = "OneTimeUse";
+
+            internal const string ProxyRestriction = "ProxyRestriction";
+
+            internal const string Count = "Count";
         }
     }
 }


### PR DESCRIPTION
This PR attempts to add to support for saml2:Conditions for AuthnRequests. The reason being Audience and  it's surronding tags are expected by the Danish public sector innative "ContextHandler" as part of their "Den fælleskommunale rammearkitektur".

There are a few more feilds and types that could be implmented before this feature can be considered complete for requests.
Expected attributes for the "Condition" element tree was found here: https://docs.oasis-open.org/security/saml/v2.0/saml-schema-assertion-2.0.xsd

There is no support for Saml2Response handling in this PR.

I'm creating the PR in order to figure out if this is someting you want as part of the pakcage at all (@Revsgaard)

Best Regards
Stefan