### PR TITLE
Update RequestedAttribute.cs

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/RequestedAttribute.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/RequestedAttribute.cs
@@ -6,17 +6,19 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
     public class RequestedAttribute
     {
         const string elementName = Saml2MetadataConstants.Message.RequestedAttribute;
-        const string nameFormat = Saml2MetadataConstants.AttributeNameFormat;
 
-        public RequestedAttribute(string name, bool isRequired = true)
+        public RequestedAttribute(string name, bool isRequired = true, string nameFormat = Saml2MetadataConstants.AttributeNameFormat)
         {
             Name = name;
             IsRequired = isRequired;
+            NameFormat = nameFormat;
         }
 
         public string Name { get; protected set; }
 
         public bool IsRequired { get; protected set; }
+        
+        public string NameFormat { get; protected set; }
 
         public XElement ToXElement()
         {
@@ -30,7 +32,7 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
         protected IEnumerable<XObject> GetXContent()
         {
             yield return new XAttribute(Saml2MetadataConstants.Message.Name, Name);
-            yield return new XAttribute(Saml2MetadataConstants.Message.NameFormat, nameFormat);
+            yield return new XAttribute(Saml2MetadataConstants.Message.NameFormat, NameFormat);
             yield return new XAttribute(Saml2MetadataConstants.Message.IsRequired, IsRequired);
         }
     }


### PR DESCRIPTION
Due to NemLogin3 requirements we need to expose metadata with RequestedAttributes that has format "urn:oasis:names:tc:SAML:2.0:attrname-format:uri" instead of "urn:oasis:names:tc:SAML:2.0:attrname-format:basic".
My suggestion should do the trick - it will not break existing code and it will allow for NameFormat changes.
Thanks for a great library :)