### PR TITLE
Search signature in children nodes

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
@@ -227,7 +227,11 @@ namespace ITfoxtec.Identity.Saml2
 
         private void ValidateXmlSignature(SignatureValidation documentValidationResult)
         {
+            if(documentValidationResult == SignatureValidation.NotPresent)
+                throw new InvalidSignatureException("Signature is missing or not found.");
+
             var assertionElement = GetAssertionElement();
+            
             if(assertionElement == null)
             {
                 if (documentValidationResult != SignatureValidation.Valid)
@@ -244,7 +248,7 @@ namespace ITfoxtec.Identity.Saml2
 
         protected SignatureValidation ValidateXmlSignature(XmlElement xmlElement)
         {
-            var xmlSignatures = xmlElement.SelectNodes($"*[local-name()='{Schemas.Saml2Constants.Message.Signature}' and namespace-uri()='{SignedXml.XmlDsigNamespaceUrl}']");
+            var xmlSignatures = xmlElement.SelectNodes($"descendant::*[local-name()='{Schemas.Saml2Constants.Message.Signature}' and namespace-uri()='{SignedXml.XmlDsigNamespaceUrl}']");
             if(xmlSignatures.Count == 0)
             {
                 return SignatureValidation.NotPresent;


### PR DESCRIPTION
To be able to verify the signature without disable the certificate validation like described in this issue: https://stackoverflow.com/questions/58603633/invalidsignatureexception-signature-is-invalid.

In addition it throws a different exception if the SignatureValidation = NotPresent  