### PR TITLE
Fix for private key not loading + useragent

### DIFF
--- a/test/TestIdPCore/Startup.cs
+++ b/test/TestIdPCore/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
@@ -30,7 +31,12 @@ namespace TestIdPCore
             services.BindConfig<Settings>(Configuration, "Settings");
             services.BindConfig<Saml2Configuration>(Configuration, "Saml2", (serviceProvider, saml2Configuration) =>
             {
-                saml2Configuration.SigningCertificate = CertificateUtil.Load(AppEnvironment.MapToPhysicalFilePath(Configuration["Saml2:SigningCertificateFile"]), Configuration["Saml2:SigningCertificatePassword"]);
+                saml2Configuration.SigningCertificate = CertificateUtil.Load(
+                    AppEnvironment.MapToPhysicalFilePath(
+                        Configuration["Saml2:SigningCertificateFile"]),
+                    Configuration["Saml2:SigningCertificatePassword"],
+                    X509KeyStorageFlags.PersistKeySet);
+
                 if (!saml2Configuration.SigningCertificate.IsValidLocalTime())
                 {
                     throw new Exception("The IdP signing certificates has expired.");
@@ -41,7 +47,9 @@ namespace TestIdPCore
             });
 
             services.AddSaml2();
-            services.AddHttpClient();
+            services.AddHttpClient(String.Empty,
+                client =>
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd("ITFoxtec.TestIdpCore"));
 
             services.AddControllersWithViews();
         }


### PR DESCRIPTION
In my experience I had a bit of difficulty getting this sample IdP code to work.
The signing certificate's private key was always NULL without adding the
```X509KeyStorageFlags.PersistKeySet``` flag.

Also, a lot of web servers are now configured to return a ```403 -
Forbidden``` response when the ```UserAgent``` header is not specified.  I
experienced this exact issue against WordPress running on the hosting
provider "Pressable."  After Googling the issue it seems there is
somewhat of a consensus to return a 403 response when said header is
left off.  Hence, the addition to ```AddHttpClient()``` where a default header
of ```ITFoxtec.TestIdpCore``` is specified for the ```UserAgent``` header.