### PR TITLE
Fix for relying party and encryption

### DIFF
--- a/test/TestIdPCore/Models/RelyingParty.cs
+++ b/test/TestIdPCore/Models/RelyingParty.cs
@@ -17,5 +17,7 @@ namespace TestIdPCore.Models
 
         public X509Certificate2 SignatureValidationCertificate { get; set; }
 
+        public X509Certificate2 AssertionEncryptionCertificate { get; set; }
+
     }
 }


### PR DESCRIPTION
Inside ```ValidateRelyingParty(string issuer)``` there is a point where an
attempt is made to load each Relying Party's metadata:

```c#
await Task.WhenAll(settings.RelyingParties.Select(rp =>
 LoadRelyingPartyAsync(rp, cancellationTokenSource)));
```

This seemed to be a bit overkill when the result returned gets filtered by the "issuer" (i.e. loading metadata for potentially 
 several unused relying parties).  Would it not make more sense to apply the "issuer" filter prior to making all of the metadata HTTP requests?

```c#
await Task.WhenAll(
 settins.RelyingParties.Where(rp=>rp.Issuer?.Equals(
		 issuer,StringComparison.InvariantCultureIgnoreCase) ?? false)
	 .Select(rp=>LoadRelyingPartyAsync(rp, cancellationTokenSource)));
```

Also, it seems that the metadata URL is only requested if the ```rp.Issuer``` is ```NULL``` or ```String.Empty```.  Since the RelyingParty is selected by the ```rp.Issuer``` field each entry in the ```appSettings.json``` file would have
to be populated.  Right?  At that point this if statement prevents the metadata URL from ever being requested.

Finally, I noticed that the encryption certificate seems to be at the ```Saml2Configuration``` level and not at the Relying Party level.  I realize this is quite a change request to the library, but most IdP's I've configured (Microsoft's ADFS and AzureAD) seem to allow specification of a SAML token/assertion encryption certificate at the Relying Party level vs. at the global IdP level.  If an IdP were to service multiple relying parties would it not be necessary to possibly store multiple unique token/assertion encryption certificates (one for each relying party)?

I've included a bit of a "hack" in this pull request to the TestIdpCore application where inside the ```LoadRelyingPartyAsync()``` method if an assertion encryption certificate is specified in the returned metadata and the ```Saml2Configuration.EncryptionCertificate``` happens to be ```NULL``` the encryption certificate returned by the Relying Party's service provider metatdata is "backfilled" into the "config" (Saml2Configuration) property.  Thought, this feels a bit "wrong" (hence "hack") and seems like the encryption certificate should be able to be specified in possibly a new ```RelyingPartyConfiguration``` object to be added in the ```ITfoxtec.Identity.Saml2``` (folder Configuration/) namespace of the library allowing relying party configuration data to exist at the "library level" vs. keeping track of the relying parties at the "application level."  Then maybe the ```Saml2Configuration``` object could posses one or more ```RelyingPartyConfiguration``` objects.  

Would this be contrary to the intended design of the library?  I could pull together what the might look like and open a new pull request instead of trying to implement the token encryption certificate selection at this level.

