### PR TITLE
adding sub-element for RequesedAttribute for compliance

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/ITfoxtec.Identity.Saml2.csproj
+++ b/src/ITfoxtec.Identity.Saml2/ITfoxtec.Identity.Saml2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netstandard2.1;net48;net462</TargetFrameworks>
+	  <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netstandard2.1;net48;net462</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Anders Revsgaard</Authors>
     <Company>ITfoxtec</Company>

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/RequestedAttribute.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/RequestedAttribute.cs
@@ -14,11 +14,19 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
             NameFormat = nameFormat;
         }
 
+        public RequestedAttribute(string name, string attributeValue, bool isRequired = true, string nameFormat = Saml2MetadataConstants.AttributeNameFormat)
+            : this(name, isRequired, nameFormat)
+        {
+            AttributeValue = attributeValue;
+        }
+
         public string Name { get; protected set; }
 
         public bool IsRequired { get; protected set; }
-        
+
         public string NameFormat { get; protected set; }
+
+        public string AttributeValue { get; protected set; }
 
         public XElement ToXElement()
         {
@@ -34,6 +42,13 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
             yield return new XAttribute(Saml2MetadataConstants.Message.Name, Name);
             yield return new XAttribute(Saml2MetadataConstants.Message.NameFormat, NameFormat);
             yield return new XAttribute(Saml2MetadataConstants.Message.IsRequired, IsRequired);
+
+            if (AttributeValue != null) {
+                var attribVal = new XElement(Saml2MetadataConstants.AttributeValueNameSpace + Saml2MetadataConstants.Message.AttributeValue) {
+                    Value = AttributeValue
+                };
+                yield return new XElement(attribVal);
+            }
         }
     }
 }

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/Saml2MetadataConstants.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/Saml2MetadataConstants.cs
@@ -21,6 +21,7 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
 
         public const string AttributeNameFormat = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic";
         public const string AttributeNameFormatUri = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
+        public const string AttributeValueNameSpace = "saml:";
 
         public class Message
         {
@@ -95,6 +96,8 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
             public const string Lang = "lang";
 
             public const string RequestedAttribute = "RequestedAttribute";
+
+            public const string AttributeValue = "AttributeValue";
 
             public const string Name = "Name";
 


### PR DESCRIPTION
Expected format for attribute value
`        <md:AttributeConsumingService index="0" isDefault="true">
            <md:ServiceName xml:lang="nl-NL">Dienstnaam 1</md:ServiceName>
            <md:RequestedAttribute Name="urn:nl-eid-gdi:1.0:ServiceUUID">
                <saml:AttributeValue xsi:type="xs:string">f847dc11-ac24-47b2-84a8-a057440ce56d</saml:AttributeValue>
            </md:RequestedAttribute>
        </md:AttributeConsumingService>
`

Please note the `saml:AttributeValue` field. This is expected in the metadata when SP publishes metadata to IdP.