### PR TITLE
Signature Validation with Multiple Signatures Present

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnResponse.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnResponse.cs
@@ -258,7 +258,7 @@ namespace ITfoxtec.Identity.Saml2
         {
             if (assertionElementCache == null)
             {
-                assertionElementCache = GetAssertionElementReference().ToXmlDocument().DocumentElement;
+                assertionElementCache = GetAssertionElementReference();
             }            
             return assertionElementCache;
         }


### PR DESCRIPTION
fix: fixed an issue where signature validation would fail on the assertion if the SAML Response had multiple signatures in it (one for the Assertion, one for the Response as a whole)

fixes #119 