### PR TITLE
fix for RequestedAttribute value namespace

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/RequestedAttribute.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/RequestedAttribute.cs
@@ -44,7 +44,7 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
             yield return new XAttribute(Saml2MetadataConstants.Message.IsRequired, IsRequired);
 
             if (AttributeValue != null) {
-                var attribVal = new XElement(Saml2MetadataConstants.SamlAssertionNamespaceNameX + Saml2MetadataConstants.Message.AttributeValue) {
+                var attribVal = new XElement(Saml2MetadataConstants.SamlAssertionNamespaceX + Saml2MetadataConstants.Message.AttributeValue) {
                     Value = AttributeValue
                 };
                 yield return new XElement(attribVal);


### PR DESCRIPTION
@Revsgaard : pls review and accept this fix. metadata generation fails otherwise when `RequestedAttribute` is having a child with `AttributeValue`.
something like
```
        <m:AttributeConsumingService index="0" isDefault="true">
            <m:ServiceName xml:lang="en-US">Service 1</m:ServiceName>
            <m:RequestedAttribute Name="urn:nl-eid-gdi:1.0:ServiceUUID">
                <saml:AttributeValue xsi:type="xs:string">f847dc11-ac24-47b2-84a8-a057440ce56d</saml:AttributeValue>
            </m:RequestedAttribute>
        </m:AttributeConsumingService>
```