### PR TITLE
Add support for encrypted Subject

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Configuration/Saml2IdentityConfiguration.cs
+++ b/src/ITfoxtec.Identity.Saml2/Configuration/Saml2IdentityConfiguration.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using ITfoxtec.Identity.Saml2.Util;
 using Microsoft.IdentityModel.Tokens;
 using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
 using System.IdentityModel.Selectors;
 #endif
 
@@ -25,6 +26,8 @@ namespace ITfoxtec.Identity.Saml2.Configuration
 
 #if !NETFULL
         public X509CertificateValidator CertificateValidator { get; set; }
+
+        public X509Certificate2 DecryptionCertificate { get; set; }
 #endif
 
         public static Saml2IdentityConfiguration GetIdentityConfiguration(Saml2Configuration config)
@@ -72,6 +75,7 @@ namespace ITfoxtec.Identity.Saml2.Configuration
                 CertificateValidationMode = config.CertificateValidationMode,
                 RevocationMode = config.RevocationMode,
             };
+            configuration.DecryptionCertificate = config.DecryptionCertificate;
             SetCustomCertificateValidator(configuration, config);
 #endif
 

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnResponse.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnResponse.cs
@@ -76,7 +76,7 @@ namespace ITfoxtec.Identity.Saml2
                     throw new ArgumentException("No RSA Public Key present in Encryption Certificate.");
                 }
             }
-            Saml2SecurityTokenHandler = Saml2ResponseSecurityTokenHandler.GetSaml2SecurityTokenHandler(IdentityConfiguration, Config?.DecryptionCertificate?.GetSamlRSAPrivateKey());
+            Saml2SecurityTokenHandler = Saml2ResponseSecurityTokenHandler.GetSaml2SecurityTokenHandler(IdentityConfiguration);
         }
 
         protected override void ValidateElementName()

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnResponse.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnResponse.cs
@@ -76,7 +76,7 @@ namespace ITfoxtec.Identity.Saml2
                     throw new ArgumentException("No RSA Public Key present in Encryption Certificate.");
                 }
             }
-            Saml2SecurityTokenHandler = Saml2ResponseSecurityTokenHandler.GetSaml2SecurityTokenHandler(IdentityConfiguration);
+            Saml2SecurityTokenHandler = Saml2ResponseSecurityTokenHandler.GetSaml2SecurityTokenHandler(IdentityConfiguration, Config?.DecryptionCertificate?.GetSamlRSAPrivateKey());
         }
 
         protected override void ValidateElementName()

--- a/src/ITfoxtec.Identity.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
+++ b/src/ITfoxtec.Identity.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
@@ -47,9 +47,9 @@ namespace ITfoxtec.Identity.Saml2.Tokens
             handler.SamlSecurityTokenRequirement.NameClaimType = ClaimTypes.NameIdentifier;
 #else
             handler.TokenValidationParameters = configuration;
-#endif
             if (decryptionKey != null)
                 handler.Serializer = new Saml2TokenSerializer(decryptionKey);
+#endif
             return handler;
         }
 

--- a/src/ITfoxtec.Identity.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
+++ b/src/ITfoxtec.Identity.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using System.Xml;
+using System.Security.Cryptography;
 #if NETFULL
 using System;
 using System.IO;
@@ -25,7 +26,7 @@ namespace ITfoxtec.Identity.Saml2.Tokens
         public TokenValidationParameters TokenValidationParameters { get; protected set; }
 #endif
 
-        public static Saml2ResponseSecurityTokenHandler GetSaml2SecurityTokenHandler(Saml2IdentityConfiguration configuration)
+        public static Saml2ResponseSecurityTokenHandler GetSaml2SecurityTokenHandler(Saml2IdentityConfiguration configuration, RSA decryptionKey)
         {
             var handler = new Saml2ResponseSecurityTokenHandler();
 #if NETFULL
@@ -47,6 +48,8 @@ namespace ITfoxtec.Identity.Saml2.Tokens
 #else
             handler.TokenValidationParameters = configuration;
 #endif
+            if (decryptionKey != null)
+                handler.Serializer = new Saml2TokenSerializer(decryptionKey);
             return handler;
         }
 

--- a/src/ITfoxtec.Identity.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
+++ b/src/ITfoxtec.Identity.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using System.Xml;
-using System.Security.Cryptography;
 #if NETFULL
 using System;
 using System.IO;
@@ -26,7 +25,7 @@ namespace ITfoxtec.Identity.Saml2.Tokens
         public TokenValidationParameters TokenValidationParameters { get; protected set; }
 #endif
 
-        public static Saml2ResponseSecurityTokenHandler GetSaml2SecurityTokenHandler(Saml2IdentityConfiguration configuration, RSA decryptionKey)
+        public static Saml2ResponseSecurityTokenHandler GetSaml2SecurityTokenHandler(Saml2IdentityConfiguration configuration)
         {
             var handler = new Saml2ResponseSecurityTokenHandler();
 #if NETFULL
@@ -47,8 +46,10 @@ namespace ITfoxtec.Identity.Saml2.Tokens
             handler.SamlSecurityTokenRequirement.NameClaimType = ClaimTypes.NameIdentifier;
 #else
             handler.TokenValidationParameters = configuration;
-            if (decryptionKey != null)
-                handler.Serializer = new Saml2TokenSerializer(decryptionKey);
+            if (configuration.DecryptionCertificate != null)
+            {
+                handler.Serializer = new Saml2TokenSerializer(configuration.DecryptionCertificate);
+            }
 #endif
             return handler;
         }

--- a/src/ITfoxtec.Identity.Saml2/Tokens/Saml2TokenSerializer.cs
+++ b/src/ITfoxtec.Identity.Saml2/Tokens/Saml2TokenSerializer.cs
@@ -1,4 +1,5 @@
-﻿using ITfoxtec.Identity.Saml2.Cryptography;
+﻿#if !NETFULL
+using ITfoxtec.Identity.Saml2.Cryptography;
 using Microsoft.IdentityModel.Tokens.Saml2;
 using System;
 using System.Collections.Generic;
@@ -35,3 +36,4 @@ namespace ITfoxtec.Identity.Saml2.Tokens
         }
     }
 }
+#endif

--- a/src/ITfoxtec.Identity.Saml2/Tokens/Saml2TokenSerializer.cs
+++ b/src/ITfoxtec.Identity.Saml2/Tokens/Saml2TokenSerializer.cs
@@ -1,0 +1,37 @@
+﻿using ITfoxtec.Identity.Saml2.Cryptography;
+using Microsoft.IdentityModel.Tokens.Saml2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace ITfoxtec.Identity.Saml2.Tokens
+{
+    internal class Saml2TokenSerializer : Saml2Serializer
+    {
+        private readonly RSA encryptionPrivateKey;
+
+        public Saml2TokenSerializer(RSA encryptionPrivateKey) : base() 
+        {
+            this.encryptionPrivateKey = encryptionPrivateKey;
+        }
+
+        protected override Saml2NameIdentifier ReadEncryptedId(XmlDictionaryReader reader)
+        {
+            var xmlDoc = new XmlDocument(reader.NameTable);
+            xmlDoc.PreserveWhitespace = true;
+            xmlDoc.LoadXml(reader.ReadOuterXml());
+            XmlElement decrypted = null;
+
+            var enc = new Saml2EncryptedXml(xmlDoc, encryptionPrivateKey);
+            enc.DecryptDocument();
+            decrypted = xmlDoc.DocumentElement;
+
+            reader = XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(decrypted.FirstChild));
+            return ReadNameIdentifier(reader, null);
+        }
+    }
+}


### PR DESCRIPTION
Fixes IDX13102: Exception thrown while reading 'Subject' for Saml2SecurityToken. Inner exception: 'System.NotSupportedException: IDX13140: EncryptedId is not supported