### PR TITLE
Non-generic typing of Saml2Binding

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Bindings/Saml2ArtifactBinding.cs
+++ b/src/ITfoxtec.Identity.Saml2/Bindings/Saml2ArtifactBinding.cs
@@ -7,7 +7,7 @@ using ITfoxtec.Identity.Saml2.Http;
 
 namespace ITfoxtec.Identity.Saml2
 {
-    public class Saml2ArtifactBinding : Saml2Binding<Saml2ArtifactBinding> 
+    public class Saml2ArtifactBinding : Saml2Binding
     {
         /// <summary>
         /// [Optional]
@@ -22,7 +22,7 @@ namespace ITfoxtec.Identity.Saml2
             CertificateIncludeOption = X509IncludeOption.EndCertOnly;
         }
 
-        protected override Saml2ArtifactBinding BindInternal(Saml2Request saml2Request, string messageName)
+        protected internal override void BindInternal(Saml2Request saml2Request, string messageName)
         {
             if (!(saml2Request is Saml2ArtifactResolve saml2ArtifactResolve))
                 throw new ArgumentException("Only Saml2ArtifactResolve is supported");
@@ -33,8 +33,6 @@ namespace ITfoxtec.Identity.Saml2
 
             var requestQueryString = string.Join("&", RequestQueryString(saml2ArtifactResolve, messageName));
             RedirectLocation = new Uri(string.Join(saml2ArtifactResolve.Destination.OriginalString.Contains('?') ? "&" : "?", saml2ArtifactResolve.Destination.OriginalString, requestQueryString));
-
-            return this;
         }
 
         private IEnumerable<string> RequestQueryString(Saml2ArtifactResolve saml2ArtifactResolve, string messageName)

--- a/src/ITfoxtec.Identity.Saml2/Bindings/Saml2Binding.cs
+++ b/src/ITfoxtec.Identity.Saml2/Bindings/Saml2Binding.cs
@@ -8,7 +8,7 @@ using System.Xml;
 
 namespace ITfoxtec.Identity.Saml2
 {
-    public abstract class Saml2Binding<T>
+    public abstract class Saml2Binding
     {
         public XmlDocument XmlDocument { get; protected set; }
 
@@ -26,22 +26,7 @@ namespace ITfoxtec.Identity.Saml2
         public Saml2Binding()
         { }
 
-        public T Bind(Saml2Request saml2Request)
-        {
-            return BindInternal(saml2Request, Saml2Constants.Message.SamlRequest);
-        }
-
-        public T Bind(Saml2Response saml2Response)
-        {
-            return BindInternal(saml2Response, Saml2Constants.Message.SamlResponse);
-        }
-
-        public T Bind(Saml2ArtifactResolve saml2ArtifactResolve)
-        {
-            return BindInternal(saml2ArtifactResolve, Saml2Constants.Message.SamlArt);
-        }
-
-        protected virtual Saml2Binding<T> BindInternal(Saml2Request saml2RequestResponse, bool createXml = true)
+        protected internal virtual void BindInternal(Saml2Request saml2RequestResponse, bool createXml = true)
         {
             if (saml2RequestResponse == null)
                 throw new ArgumentNullException(nameof(saml2RequestResponse));
@@ -65,10 +50,9 @@ namespace ITfoxtec.Identity.Saml2
                 Debug.WriteLine("Saml2P: " + XmlDocument.OuterXml);
 #endif
             }
-            return this;
         }
 
-        protected abstract T BindInternal(Saml2Request saml2RequestResponse, string messageName);
+        protected internal abstract void BindInternal(Saml2Request saml2RequestResponse, string messageName);
 
         public Saml2Request Unbind(HttpRequest request, Saml2Request saml2Request)
         {
@@ -95,7 +79,7 @@ namespace ITfoxtec.Identity.Saml2
 
             if (saml2RequestResponse.Config == null)
                 throw new ArgumentNullException("saml2RequestResponse.Config");
-            
+
             SetSignatureValidationCertificates(saml2RequestResponse);
 
             return saml2RequestResponse;

--- a/src/ITfoxtec.Identity.Saml2/Bindings/Saml2PostBinding.cs
+++ b/src/ITfoxtec.Identity.Saml2/Bindings/Saml2PostBinding.cs
@@ -10,7 +10,7 @@ using System.Net;
 
 namespace ITfoxtec.Identity.Saml2
 {
-    public class Saml2PostBinding : Saml2Binding<Saml2PostBinding>
+    public class Saml2PostBinding : Saml2Binding
     {
         /// <summary>
         /// [Optional]
@@ -28,7 +28,7 @@ namespace ITfoxtec.Identity.Saml2
             CertificateIncludeOption = X509IncludeOption.EndCertOnly;
         }
 
-        protected override Saml2PostBinding BindInternal(Saml2Request saml2RequestResponse, string messageName)
+        protected internal override void BindInternal(Saml2Request saml2RequestResponse, string messageName)
         {
             BindInternal(saml2RequestResponse);
 
@@ -55,7 +55,6 @@ namespace ITfoxtec.Identity.Saml2
             }
 
             PostContent = string.Concat(HtmlPostPage(saml2RequestResponse.Destination, messageName));
-            return this;
         }
 
         private IEnumerable<string> HtmlPostPage(Uri destination, string messageName)

--- a/src/ITfoxtec.Identity.Saml2/Bindings/Saml2RedirectBinding.cs
+++ b/src/ITfoxtec.Identity.Saml2/Bindings/Saml2RedirectBinding.cs
@@ -13,13 +13,13 @@ using ITfoxtec.Identity.Saml2.Http;
 
 namespace ITfoxtec.Identity.Saml2
 {
-    public class Saml2RedirectBinding : Saml2Binding<Saml2RedirectBinding>
+    public class Saml2RedirectBinding : Saml2Binding
     {
         public Uri RedirectLocation { get; protected set; }
 
         public string Signature { get; protected set; }
 
-        protected override Saml2RedirectBinding BindInternal(Saml2Request saml2RequestResponse, string messageName)
+        protected internal override void BindInternal(Saml2Request saml2RequestResponse, string messageName)
         {
             base.BindInternal(saml2RequestResponse);
 
@@ -50,8 +50,6 @@ namespace ITfoxtec.Identity.Saml2
             }
 
             RedirectLocation = new Uri(string.Join(saml2RequestResponse.Destination.OriginalString.Contains('?') ? "&" : "?", saml2RequestResponse.Destination.OriginalString, requestQueryString));
-
-            return this;
         }
 
         private string SigneQueryString(string queryString, X509Certificate2 signingCertificate)

--- a/src/ITfoxtec.Identity.Saml2/Bindings/Saml2SoapEnvelope.cs
+++ b/src/ITfoxtec.Identity.Saml2/Bindings/Saml2SoapEnvelope.cs
@@ -14,14 +14,14 @@ using System.Xml.Linq;
 
 namespace ITfoxtec.Identity.Saml2
 {
-    public class Saml2SoapEnvelope : Saml2Binding<Saml2SoapEnvelope>
+    public class Saml2SoapEnvelope : Saml2Binding
     {
         /// <summary>
         /// SOAP response XML.
         /// </summary>
         public string SoapResponseXml { get; set; }
 
-        protected override Saml2SoapEnvelope BindInternal(Saml2Request saml2Request, string messageName)
+        protected internal override void BindInternal(Saml2Request saml2Request, string messageName)
         {
             if (!(saml2Request is Saml2ArtifactResponse))
                 throw new ArgumentException("Only Saml2ArtifactResponse is supported");
@@ -29,7 +29,6 @@ namespace ITfoxtec.Identity.Saml2
             BindInternal(saml2Request);
 
             SoapResponseXml = ToSoapXml();
-            return this;
         }
 
         protected override Saml2Request UnbindInternal(HttpRequest request, Saml2Request saml2Request, string messageName)

--- a/src/ITfoxtec.Identity.Saml2/Extensions/Saml2BindingExtensions.cs
+++ b/src/ITfoxtec.Identity.Saml2/Extensions/Saml2BindingExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ITfoxtec.Identity.Saml2.Schemas;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -7,10 +8,29 @@ namespace ITfoxtec.Identity.Saml2
 {
     public static class Saml2BindingExtensions
     {
+        public static T Bind<T>(this T binding, Saml2Request saml2Request) where T : Saml2Binding
+        {
+            binding.BindInternal(saml2Request, Saml2Constants.Message.SamlRequest);
+            return binding;
+        }
+
+        public static T Bind<T>(this T binding, Saml2Response saml2Response) where T : Saml2Binding
+        {
+            binding.BindInternal(saml2Response, Saml2Constants.Message.SamlResponse);
+            return binding;
+        }
+
+        public static T Bind<T>(this T binding, Saml2ArtifactResolve saml2ArtifactResolve) where T : Saml2Binding
+        {
+            binding.BindInternal(saml2ArtifactResolve, Saml2Constants.Message.SamlArt);
+            return binding;
+        }
+
         /// <summary>
         /// Set a Dictionary of key value pairs as a Query string in the Relay State.
         /// </summary>
-        public static string SetRelayStateQuery<T>(this Saml2Binding<T> saml2Binding, Dictionary<string, string> elements)
+        public static string SetRelayStateQuery<T>(this T saml2Binding, Dictionary<string, string> elements)
+            where T : Saml2Binding
         {
             if(elements == null)
             {
@@ -32,7 +52,8 @@ namespace ITfoxtec.Identity.Saml2
         /// <summary>
         /// Get the Relay State Query string as a Dictionary of key value pairs.
         /// </summary>
-        public static Dictionary<string, string> GetRelayStateQuery<T>(this Saml2Binding<T> saml2Binding)
+        public static Dictionary<string, string> GetRelayStateQuery<T>(this T saml2Binding)
+            where T : Saml2Binding
         {
             Dictionary<string, string> elements = new Dictionary<string,string>();
             if(string.IsNullOrWhiteSpace(saml2Binding.RelayState))

--- a/test/TestIdPCore/Controllers/AuthController.cs
+++ b/test/TestIdPCore/Controllers/AuthController.cs
@@ -124,17 +124,17 @@ namespace TestIdPCore.Controllers
             }
         }
 
-        private string ReadRelyingPartyFromLoginRequest<T>(Saml2Binding<T> binding)
+        private string ReadRelyingPartyFromLoginRequest(Saml2Binding binding)
         {
             return binding.ReadSamlRequest(Request.ToGenericHttpRequest(), new Saml2AuthnRequest(GetRpSaml2Configuration()))?.Issuer;
         }
 
-        private string ReadRelyingPartyFromLogoutRequest<T>(Saml2Binding<T> binding)
+        private string ReadRelyingPartyFromLogoutRequest(Saml2Binding binding)
         {
             return binding.ReadSamlRequest(Request.ToGenericHttpRequest(), new Saml2LogoutRequest(GetRpSaml2Configuration()))?.Issuer;
         }
 
-        private string ReadRelyingPartyFromSoapEnvelopeRequest<T>(ITfoxtec.Identity.Saml2.Http.HttpRequest httpRequest, Saml2Binding<T> binding)
+        private string ReadRelyingPartyFromSoapEnvelopeRequest(ITfoxtec.Identity.Saml2.Http.HttpRequest httpRequest, Saml2Binding binding)
         {
             return binding.ReadSamlRequest(httpRequest, new Saml2ArtifactResolve(GetRpSaml2Configuration()))?.Issuer;
         }
@@ -173,7 +173,7 @@ namespace TestIdPCore.Controllers
 
                 var token = saml2AuthnResponse.CreateSecurityToken(relyingParty.Issuer, subjectConfirmationLifetime: 5, issuedTokenLifetime: 60);
             }
-
+            
             return responsebinding.Bind(saml2AuthnResponse).ToActionResult();
         }
 


### PR DESCRIPTION
## Background
Prior to this change it was not possible to type a variable as `Saml2Binding` with no knowledge of the implementing type.

So if I want to write a `ResolveBindingForSomething(...)` method then I'm pretty much stuck because of typing limitations.

## Change
The core change is to remove the `<T>` parameter of `Saml2Binding`. To support this I made `BindInternal` agnostic and changed the `Bind` methods into extensions that will organically return the same `T`.

## Result
I can now write code that does not know about underlying types:
```
var binding = ResolveBindingForSomething(...);
binding.ReadSamlResponse(httpRequest, samlResponse);
binding.Unbind(httpRequest, samlResponse);
var relayStateQuery = binding.GetRelayStateQuery();
```