### PR TITLE
Update AuthController.cs

### DIFF
--- a/test/TestIdPCore/Controllers/AuthController.cs
+++ b/test/TestIdPCore/Controllers/AuthController.cs
@@ -253,8 +253,8 @@ namespace TestIdPCore.Controllers
 
         private async Task<RelyingParty> ValidateRelyingParty(string issuer)
         {
-            using var cancellationTokenSource = new CancellationTokenSource(3 * 1000); // Cancel after 3 seconds.
-            await Task.WhenAll(settings.RelyingParties.Select(rp => LoadRelyingPartyAsync(rp, cancellationTokenSource)));
+            // Create a cancellation token for each Relying Party call
+            await Task.WhenAll(settings.RelyingParties.Select(rp => LoadRelyingPartyAsync(rp, new CancellationTokenSource(1 * 1000))));
 
             return settings.RelyingParties.Where(rp => rp.Issuer != null && rp.Issuer.Equals(issuer, StringComparison.InvariantCultureIgnoreCase)).Single();
         }


### PR DESCRIPTION
Create a cancellation token for each Relying Party call as if one of them got error while downloading the remaining keep processing.