### PR TITLE
Update Saml2Request.cs

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
@@ -263,12 +263,13 @@ namespace ITfoxtec.Identity.Saml2
 
             foreach (var signatureValidationCertificate in SignatureValidationCertificates)
             {
-                IdentityConfiguration.CertificateValidator.Validate(signatureValidationCertificate);
-
                 var signedXml = new Saml2SignedXml(xmlElement, signatureValidationCertificate, SignatureAlgorithm, XmlCanonicalizationMethod);
                 signedXml.LoadXml(xmlSignatures[0] as XmlElement);
                 if (signedXml.CheckSignature())
                 {
+                    // Check if certificate used to sign is valid
+                    IdentityConfiguration.CertificateValidator.Validate(signatureValidationCertificate);
+                    
                     // Signature is valid.
                     return SignatureValidation.Valid;
                 }


### PR DESCRIPTION
Hi Anders,
this is a small update to the signature validation. We have increased number of Claims Providers, that have more than one certificate in the metadata, and not all certificates are valid (this is due to OCES2->OCES3 migration). So even though, they already started signing with OCES3, they still have OCES2 in the metadata. The change ensure, that we validate only the certificate that was used to create a signature.

What do you think?

Regards,
Greg