### PR TITLE
Validate XML signature transforms

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Cryptography/Saml2SignedXml.cs
+++ b/src/ITfoxtec.Identity.Saml2/Cryptography/Saml2SignedXml.cs
@@ -41,26 +41,47 @@ namespace ITfoxtec.Identity.Saml2.Cryptography
 
         public new bool CheckSignature()
         {
+            if (SignedInfo.CanonicalizationMethod != CanonicalizationMethod)
+            {
+                throw new InvalidSignatureException(
+                    $"Illegal canonicalization method {SignedInfo.CanonicalizationMethod} used in signature.");
+            }
+
+            if (SignedInfo.SignatureMethod != Saml2Signer.SignatureAlgorithm)
+            {
+                throw new InvalidSignatureException($"Illegal signature method {SignedInfo.SignatureMethod} used in signature.");
+            }
+
             if (SignedInfo.References.Count != 1)
             {
                 throw new InvalidSignatureException("Invalid XML signature reference.");
             }
 
-            var referenceId = (SignedInfo.References[0] as Reference).Uri.Substring(1);
+            var reference = SignedInfo.References[0] as Reference;
+            AssertReferenceValid(reference);
+
+            return CheckSignature(Saml2Signer.Certificate.GetRSAPublicKey());
+        }
+
+        private void AssertReferenceValid(Reference reference)
+        {
+            var referenceId = reference.Uri.Substring(1);
             if (Element != GetIdElement(Element.OwnerDocument, referenceId))
             {
                 throw new InvalidSignatureException("XML signature reference do not refer to the root element.");
             }
+            AssertTransformChainValid(reference.TransformChain);
+        }
 
-            var canonicalizationMethodValid = SignedInfo.CanonicalizationMethod == CanonicalizationMethod;
-            var signatureMethodValid = SignedInfo.SignatureMethod == Saml2Signer.SignatureAlgorithm;
-            if (!(canonicalizationMethodValid && signatureMethodValid))
+        private void AssertTransformChainValid(TransformChain transformChain)
+        {
+            foreach (Transform transform in transformChain)
             {
-                return false;
-            }
-            else
-            {                        
-                return CheckSignature(Saml2Signer.Certificate.GetRSAPublicKey());
+                var algorithm = transform.Algorithm;
+                if (algorithm != XmlDsigEnvelopedSignatureTransformUrl && algorithm != CanonicalizationMethod)
+                {
+                    throw new InvalidSignatureException($"Illegal transform method {algorithm} used in signature.");
+                }
             }
         }
     }


### PR DESCRIPTION
- When the XML signature on SAML message is validated, extra validation is added to ensure that only allowed XML DSig transform algorithms are used. 

- If an unexpected signature method or canonicalization method is used in the SignedInfo element, an exception is thrown. Previously, the signature was reported as invalid in this case.
