### PR TITLE
Add name qualifier and sp name qualifier to logout request

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Claims/Saml2ClaimTypes.cs
+++ b/src/ITfoxtec.Identity.Saml2/Claims/Saml2ClaimTypes.cs
@@ -5,6 +5,8 @@ namespace ITfoxtec.Identity.Saml2.Claims
     {
         public const string NameId = "http://schemas.itfoxtec.com/ws/2014/02/identity/claims/saml2nameid";
         public const string NameIdFormat = "http://schemas.itfoxtec.com/ws/2014/02/identity/claims/saml2nameidformat";
+        public const string NameQualifier = "http://schemas.itfoxtec.com/ws/2014/02/identity/claims/saml2namequalifier";
+        public const string SPNameQualifier = "http://schemas.itfoxtec.com/ws/2014/02/identity/claims/saml2spnamequalifier";
         public const string SessionIndex = "http://schemas.itfoxtec.com/ws/2014/02/identity/claims/saml2sessionindex";
     }
 }

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2LogoutRequest.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2LogoutRequest.cs
@@ -57,6 +57,16 @@ namespace ITfoxtec.Identity.Saml2
                     NameId = new Saml2NameIdentifier(ReadClaimValue(identity, Saml2ClaimTypes.NameId), new Uri(nameIdFormat));
 
                 }
+                var nameIdNameQualifier = ReadClaimValue(identity, Saml2ClaimTypes.NameQualifier, false);
+                if (!string.IsNullOrEmpty(nameIdNameQualifier))
+                {
+                    NameId.NameQualifier = nameIdNameQualifier;
+                }
+                var nameIdSPNameQualifier = ReadClaimValue(identity, Saml2ClaimTypes.SPNameQualifier, false);
+                if (!string.IsNullOrEmpty(nameIdSPNameQualifier))
+                {
+                    NameId.SPNameQualifier = nameIdSPNameQualifier;
+                }
                 SessionIndex = ReadClaimValue(identity, Saml2ClaimTypes.SessionIndex, false);
             }
         }
@@ -103,15 +113,20 @@ namespace ITfoxtec.Identity.Saml2
 
             if (NameId != null)
             {
-                object[] nameIdContent;
+                var nameIdContent = new List<object>() { NameId.Value };
                 if (NameId.Format != null)
                 {
-                    nameIdContent = new object[] { NameId.Value, new XAttribute(Schemas.Saml2Constants.Message.Format, NameId.Format) };
+                    nameIdContent.Add(new XAttribute(Schemas.Saml2Constants.Message.Format, NameId.Format));
                 }
-                else
+                if (NameId.NameQualifier != null)
                 {
-                    nameIdContent = new object[] { NameId.Value };
+                    nameIdContent.Add(new XAttribute(Schemas.Saml2Constants.Message.NameQualifier, NameId.NameQualifier));
                 }
+                if (NameId.SPNameQualifier != null)
+                {
+                    nameIdContent.Add(new XAttribute(Schemas.Saml2Constants.Message.SpNameQualifier, NameId.SPNameQualifier));
+                }
+
                 yield return new XElement(Schemas.Saml2Constants.AssertionNamespaceX + Schemas.Saml2Constants.Message.NameId, nameIdContent);
             }
 
@@ -126,6 +141,8 @@ namespace ITfoxtec.Identity.Saml2
             base.Read(xml, validate, detectReplayedTokens);
 
             NameId = XmlDocument.DocumentElement[Schemas.Saml2Constants.Message.NameId, Schemas.Saml2Constants.AssertionNamespace.OriginalString].GetValueOrNull<Saml2NameIdentifier>();
+            NameId.NameQualifier = XmlDocument.DocumentElement[Schemas.Saml2Constants.Message.NameId, Schemas.Saml2Constants.AssertionNamespace.OriginalString].GetAttribute(Schemas.Saml2Constants.Message.NameQualifier);
+            NameId.SPNameQualifier = XmlDocument.DocumentElement[Schemas.Saml2Constants.Message.NameId, Schemas.Saml2Constants.AssertionNamespace.OriginalString].GetAttribute(Schemas.Saml2Constants.Message.SpNameQualifier);
 
             SessionIndex = XmlDocument.DocumentElement[Schemas.Saml2Constants.Message.SessionIndex, Schemas.Saml2Constants.ProtocolNamespace.OriginalString].GetValueOrNull<string>();
         }

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Saml2Constants.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Saml2Constants.cs
@@ -166,6 +166,8 @@ namespace ITfoxtec.Identity.Saml2.Schemas
 
             internal const string AllowCreate = "AllowCreate";
 
+            internal const string NameQualifier = "NameQualifier";
+
             internal const string SpNameQualifier = "SPNameQualifier";
             
             internal const string Extensions = "Extensions";

--- a/src/ITfoxtec.Identity.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
+++ b/src/ITfoxtec.Identity.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
@@ -90,18 +90,18 @@ namespace ITfoxtec.Identity.Saml2.Tokens
                 saml2Response.NameId = saml2SecurityToken.Assertion.Subject.NameId;
                 identity.AddClaim(new Claim(Saml2ClaimTypes.NameId, saml2Response.NameId.Value));
 
-               if (saml2Response.NameId.Format != null)
-               {
-                   identity.AddClaim(new Claim(Saml2ClaimTypes.NameIdFormat, saml2Response.NameId.Format.OriginalString));
-               }
-               if (saml2Response.NameId.NameQualifier != null)
-               {
-                   identity.AddClaim(new Claim(Saml2ClaimTypes.NameQualifier, saml2Response.NameId.NameQualifier));
-               }
-               if (saml2Response.NameId.SPNameQualifier != null)
-               {
-                   identity.AddClaim(new Claim(Saml2ClaimTypes.SPNameQualifier, saml2Response.NameId.SPNameQualifier));
-               }
+                if (saml2Response.NameId.Format != null)
+                {
+                    identity.AddClaim(new Claim(Saml2ClaimTypes.NameIdFormat, saml2Response.NameId.Format.OriginalString));
+                }
+                if (saml2Response.NameId.NameQualifier != null)
+                {
+                    identity.AddClaim(new Claim(Saml2ClaimTypes.NameQualifier, saml2Response.NameId.NameQualifier));
+                }
+                if (saml2Response.NameId.SPNameQualifier != null)
+                {
+                    identity.AddClaim(new Claim(Saml2ClaimTypes.SPNameQualifier, saml2Response.NameId.SPNameQualifier));
+                }
             }
 
             var sessionIndex = (saml2SecurityToken.Assertion.Statements.Where(s => s is Saml2AuthenticationStatement).FirstOrDefault() as Saml2AuthenticationStatement)?.SessionIndex;

--- a/src/ITfoxtec.Identity.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
+++ b/src/ITfoxtec.Identity.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
@@ -90,10 +90,18 @@ namespace ITfoxtec.Identity.Saml2.Tokens
                 saml2Response.NameId = saml2SecurityToken.Assertion.Subject.NameId;
                 identity.AddClaim(new Claim(Saml2ClaimTypes.NameId, saml2Response.NameId.Value));
 
-                if (saml2Response.NameId.Format != null)
-                {
-                    identity.AddClaim(new Claim(Saml2ClaimTypes.NameIdFormat, saml2Response.NameId.Format.OriginalString));
-                }
+               if (saml2Response.NameId.Format != null)
+               {
+                   identity.AddClaim(new Claim(Saml2ClaimTypes.NameIdFormat, saml2Response.NameId.Format.OriginalString));
+               }
+               if (saml2Response.NameId.NameQualifier != null)
+               {
+                   identity.AddClaim(new Claim(Saml2ClaimTypes.NameQualifier, saml2Response.NameId.NameQualifier));
+               }
+               if (saml2Response.NameId.SPNameQualifier != null)
+               {
+                   identity.AddClaim(new Claim(Saml2ClaimTypes.SPNameQualifier, saml2Response.NameId.SPNameQualifier));
+               }
             }
 
             var sessionIndex = (saml2SecurityToken.Assertion.Statements.Where(s => s is Saml2AuthenticationStatement).FirstOrDefault() as Saml2AuthenticationStatement)?.SessionIndex;


### PR DESCRIPTION
PR for StackOverflow Question: 
[ITfoxtec.Identity.Saml2 Saml2LogoutRequest - NameQualifier and SPNameQualifier come up empty](https://stackoverflow.com/questions/77868719/itfoxtec-identity-saml2-saml2logoutrequest-namequalifier-and-spnamequalifier-c) 

For the original question, to solve my particular issue, it was enough to modify the `Read` method and the `Saml2Constants`. 

The rest of the changes are for getting these two attributes among claims and to fix the method you've pointed in the response (`Saml2LogoutRequest(Saml2Configuration config, ClaimsPrincipal currentPrincipal)`)