### PR TITLE
Add support for Extensions in metadata.

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/EntityDescriptor.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/EntityDescriptor.cs
@@ -98,6 +98,15 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
         /// </summary>
         public IEnumerable<ContactPerson> ContactPersons { get; set; }
 
+        /// <summary>
+        /// [Optional]
+        /// This extension point contains optional protocol message extension XML elements that are agreed on between 
+        /// the communicating parties. No extension schema is required in order to make use of this extension point, 
+        /// and even if one is provided, the lax validation setting does not impose a requirement for the extension 
+        /// to be valid. SAML extension elements MUST be namespace-qualified in a non-SAML-defined namespace.
+        /// </summary>
+        public Schemas.Extensions Extensions { get; set; }
+
         public EntityDescriptor()
         { }
 
@@ -142,6 +151,11 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
             }
             yield return new XAttribute(Saml2MetadataConstants.MetadataNamespaceNameX, Saml2MetadataConstants.MetadataNamespace);
 
+            if (Extensions != null) 
+            {
+                yield return Extensions.ToXElement();
+            }
+            
             if (SPSsoDescriptor != null)
             {
                 yield return SPSsoDescriptor.ToXElement();

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/EntityDescriptor.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/EntityDescriptor.cs
@@ -100,12 +100,12 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
 
         /// <summary>
         /// [Optional]
-        /// This extension point contains optional protocol message extension XML elements that are agreed on between 
+        /// This extension point contains optional metadata extension XML elements that are agreed on between 
         /// the communicating parties. No extension schema is required in order to make use of this extension point, 
         /// and even if one is provided, the lax validation setting does not impose a requirement for the extension 
         /// to be valid. SAML extension elements MUST be namespace-qualified in a non-SAML-defined namespace.
         /// </summary>
-        public Schemas.Extensions Extensions { get; set; }
+        public Extensions Extensions { get; set; }
 
         public EntityDescriptor()
         { }

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/Extensions.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/Extensions.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
+{
+    /// <summary>
+    /// This extension point contains optional protocol message extension XML elements that are agreed on between 
+    /// the communicating parties.
+    /// </summary>
+    public class Extensions
+    {
+        const string elementName = Saml2Constants.Message.Extensions;
+        XElement envelope = new XElement(Saml2MetadataConstants.MetadataNamespaceX + elementName);
+
+        /// <summary>
+        /// Add extension data to the extension XML elements.
+        /// SAML extension elements MUST be namespace-qualified in a non-SAML-defined namespace.
+        /// </summary>
+        public XElement Element
+        {
+            get
+            {
+                return envelope;
+            }
+            internal set
+            {
+                envelope = value;
+            }
+        }
+
+        public XElement ToXElement()
+        {
+            if (!envelope.Name.Namespace.Equals(Saml2MetadataConstants.MetadataNamespaceX))
+            {
+                throw new Exception($"Invalid Extensions namespace. Required namespace '{Saml2MetadataConstants.MetadataNamespaceX}'.");
+            }
+            if (!envelope.Name.LocalName.Equals(elementName))
+            {
+                throw new Exception($"Invalid Extensions name. Required name '{elementName}'.");
+            }
+
+            if (envelope.Elements().Count() <= 0)
+            {
+                throw new Exception($"Extensions is empty.");
+            }
+
+            return envelope;
+        }
+    }
+}

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/Extensions.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/Extensions.cs
@@ -5,7 +5,7 @@ using System.Xml.Linq;
 namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
 {
     /// <summary>
-    /// This extension point contains optional protocol message extension XML elements that are agreed on between 
+    /// This extension point contains optional metadata extension XML elements that are agreed on between 
     /// the communicating parties.
     /// </summary>
     public class Extensions

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/IdPSsoDescriptor.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/IdPSsoDescriptor.cs
@@ -54,6 +54,11 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
                 yield return new XAttribute(Saml2MetadataConstants.Message.WantAuthnRequestsSigned, WantAuthnRequestsSigned.Value);
             }
 
+            if (Extensions != null)
+            {
+                yield return Extensions.ToXElement();
+            }
+
             if (EncryptionCertificates != null)
             {
                 foreach (var encryptionCertificate in EncryptionCertificates)

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/SPSsoDescriptor.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/SPSsoDescriptor.cs
@@ -67,6 +67,11 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
                 yield return new XAttribute(Saml2MetadataConstants.Message.WantAssertionsSigned, WantAssertionsSigned.Value);
             }
 
+            if (Extensions != null)
+            {
+                yield return Extensions.ToXElement();
+            }
+            
             if (EncryptionCertificates != null)
             {
                 foreach(var encryptionCertificate in EncryptionCertificates)

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/SsoDescriptorType.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/SsoDescriptorType.cs
@@ -72,12 +72,12 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
 
         /// <summary>
         /// [Optional]
-        /// This extension point contains optional protocol message extension XML elements that are agreed on between 
+        /// This extension point contains optional metadata extension XML elements that are agreed on between 
         /// the communicating parties. No extension schema is required in order to make use of this extension point, 
         /// and even if one is provided, the lax validation setting does not impose a requirement for the extension 
         /// to be valid. SAML extension elements MUST be namespace-qualified in a non-SAML-defined namespace.
         /// </summary>
-        public Schemas.Extensions Extensions { get; set; }
+        public Extensions Extensions { get; set; }
 
         /// <summary>
         /// Configure default encryption methods used by .NET.

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/SsoDescriptorType.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/SsoDescriptorType.cs
@@ -71,6 +71,15 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
         public IEnumerable<Uri> NameIDFormats { get; set; }
 
         /// <summary>
+        /// [Optional]
+        /// This extension point contains optional protocol message extension XML elements that are agreed on between 
+        /// the communicating parties. No extension schema is required in order to make use of this extension point, 
+        /// and even if one is provided, the lax validation setting does not impose a requirement for the extension 
+        /// to be valid. SAML extension elements MUST be namespace-qualified in a non-SAML-defined namespace.
+        /// </summary>
+        public Schemas.Extensions Extensions { get; set; }
+
+        /// <summary>
         /// Configure default encryption methods used by .NET.
         /// </summary>
         public void SetDefaultEncryptionMethods()


### PR DESCRIPTION
Adds support for Extensions in EntityDescriptor and SP/IDPSSODescriptor according to spec.
Used by e.g. Finnish provider Suomi.FI.
Metadata extensions is in a different namespace than the existing Extensions, so added that class.