### PR TITLE
Feature/support for provider name

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnRequest.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnRequest.cs
@@ -90,6 +90,11 @@ namespace ITfoxtec.Identity.Saml2
         public Uri ProtocolBinding { get; set; }
 
         /// <summary>
+        /// [Optional] 
+        /// </summary>
+        public string? ProviderName { get; set; }
+
+        /// <summary>
         /// [Optional]
         /// If present, specifies a filter for possible responses. Such a query asks the question "What assertions
         /// containing authentication statements do you have for this subject that satisfy the authentication
@@ -175,6 +180,11 @@ namespace ITfoxtec.Identity.Saml2
                 yield return new XAttribute(Saml2Constants.Message.ProtocolBinding, ProtocolBinding);
             }
 
+            if (!string.IsNullOrEmpty(ProviderName))
+            {
+                yield return new XAttribute(Saml2Constants.Message.ProviderName, ProviderName);
+            }
+
             if (Conditions != null)
             {
                 yield return Conditions.ToXElement();
@@ -216,6 +226,8 @@ namespace ITfoxtec.Identity.Saml2
             AttributeConsumingServiceIndex = XmlDocument.DocumentElement.Attributes[Saml2Constants.Message.AttributeConsumingServiceIndex].GetValueOrNull<int?>();
 
             ProtocolBinding = XmlDocument.DocumentElement.Attributes[Saml2Constants.Message.ProtocolBinding].GetValueOrNull<Uri>();
+
+            ProviderName = XmlDocument.DocumentElement.Attributes[Saml2Constants.Message.ProviderName].GetValueOrNull<string>();
 
             Subject = XmlDocument.DocumentElement[Saml2Constants.Message.Subject, Saml2Constants.AssertionNamespace.OriginalString].GetElementOrNull<Subject>();
 

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Saml2Constants.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Saml2Constants.cs
@@ -211,6 +211,9 @@ namespace ITfoxtec.Identity.Saml2.Schemas
             internal const string Loc = "Loc";
 
             internal const string GetComplete = "GetComplete";
+            
+            internal const string ProviderName = "ProviderName";
+
         }
     }
 }


### PR DESCRIPTION
Added support for ProviderName: string property as part of the AuthnRequest.

@Revsgaard Hope you don't mind I added this one too? :) 