### PR TITLE
Support `EntitiesDescriptor` as metadata root element

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2Metadata.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2Metadata.cs
@@ -1,5 +1,18 @@
-﻿using ITfoxtec.Identity.Saml2.Schemas.Metadata;
+﻿using ITfoxtec.Identity.Saml2.Schemas;
+using ITfoxtec.Identity.Saml2.Schemas.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
 using System.Xml;
+using System.Xml.Linq;
+#if NETFULL
+using System.IdentityModel.Tokens;
+#else
+using Microsoft.IdentityModel.Tokens.Saml2;
+#endif
 
 namespace ITfoxtec.Identity.Saml2
 {
@@ -8,17 +21,77 @@ namespace ITfoxtec.Identity.Saml2
     /// </summary>
     public class Saml2Metadata
     {
-        /// <param name="entityDescriptor">[Required] The EntitiesDescriptor element contains the metadata for an optionally named group of SAML entities.</param>
-        public Saml2Metadata(EntityDescriptor entityDescriptor)
+        /// <param name="entitiesDescriptor">[Required] The EntitiesDescriptor element contains the metadata for an optionally named group of SAML entities.</param>
+        public Saml2Metadata(params EntityDescriptor[] entitiesDescriptor)
         {
-            EntityDescriptor = entityDescriptor;
+            EntitiesDescriptor = entitiesDescriptor;
+        }
+
+        /// <param name="entitiesDescriptor">[Required] The EntitiesDescriptor element contains the metadata for an optionally named group of SAML entities.</param>
+        public Saml2Metadata(Saml2Configuration config, params EntityDescriptor[] entitiesDescriptor)
+        {
+            EntitiesDescriptor = entitiesDescriptor;
+            MetadataSigningCertificate = config.SigningCertificate;
+            SignatureAlgorithm = config.SignatureAlgorithm;
+            XmlCanonicalizationMethod = config.XmlCanonicalizationMethod;
         }
 
         /// <summary>
-        /// [Required]
-        /// The EntitiesDescriptor element contains the metadata for an optionally named group of SAML entities.
+        /// [Optional]
+        /// The EntitiesDescriptor element contains the metadata for a group of SAML entities.
         /// </summary>
-        public EntityDescriptor EntityDescriptor { get; protected set; }
+        public IEnumerable<EntityDescriptor> EntitiesDescriptor { get; set; }
+
+        /// <summary>
+        /// [Required]
+        /// The EntityDescriptor element contains the metadata for a single SAML entity.
+        /// </summary>
+        [Obsolete("The " + nameof(EntityDescriptor) + " is deprecated. Please use " + nameof(EntitiesDescriptor) + " which is a list of entity descriptors.")]
+        public EntityDescriptor EntityDescriptor { get => EntitiesDescriptor.FirstOrDefault(); set => EntitiesDescriptor = new[] { value }; }
+
+        /// <summary>
+        /// [Optional]
+        /// An metadata XML signature that authenticates the containing element and its contents.
+        /// </summary>
+        public X509Certificate2 MetadataSigningCertificate { get; set; }
+
+        /// <summary>
+        /// [Optional]
+        /// Default EndCertOnly (Only the end certificate is included in the X.509 chain information).
+        /// </summary>
+        public X509IncludeOption CertificateIncludeOption { get; set; } = X509IncludeOption.EndCertOnly;
+
+        /// <summary>
+        /// [Optional]
+        /// Optional attribute indicates the expiration time of the metadata and any contained elements.
+        /// 
+        /// Metadata is valid until in days from now.
+        /// </summary>
+        public int? ValidUntil { get; set; }
+
+        /// <summary>
+        /// Signature algorithm to use when signing.
+        /// </summary>
+        public string SignatureAlgorithm { get; set; } = Saml2SecurityAlgorithms.RsaSha256Signature;
+
+        /// <summary>
+        /// XML Canonicalization method to use when signing.
+        /// </summary>
+        public string XmlCanonicalizationMethod { get; set; } = SignedXml.XmlDsigExcC14NTransformUrl;
+
+        /// <summary>
+        /// A document-unique identifier for the element, typically used as a reference point when signing.
+        /// </summary>
+        public Saml2Id Id { get; protected set; } = new Saml2Id();
+
+        /// <summary>
+        /// The ID as string.
+        /// </summary>
+        /// <value>The ID string.</value>
+        public string IdAsString
+        {
+            get { return Id.Value; }
+        }
 
         /// <summary>
         /// Saml2 metadata Xml Document.
@@ -38,8 +111,46 @@ namespace ITfoxtec.Identity.Saml2
         /// </summary>
         public Saml2Metadata CreateMetadata()
         {
-            XmlDocument = EntityDescriptor.ToXmlDocument();
+            var xmlDocument = ToXElement().ToXmlDocument();
+            if (MetadataSigningCertificate != null)
+            {
+                xmlDocument.SignDocument(MetadataSigningCertificate, SignatureAlgorithm, XmlCanonicalizationMethod, CertificateIncludeOption, IdAsString);
+            }
+            XmlDocument = xmlDocument;
             return this;
+        }
+
+        protected XElement ToXElement()
+        {
+            if (EntitiesDescriptor.Count() == 1)
+            {
+                var singleDescriptorMetadata = EntityDescriptor.ToXElement();
+                //‌ Copy Id for signing
+                Id = EntityDescriptor.Id;
+                singleDescriptorMetadata.SetAttributeValue(Saml2MetadataConstants.MetadataNamespaceNameX, Saml2MetadataConstants.MetadataNamespace);
+                if (ValidUntil.HasValue)
+                {
+                    singleDescriptorMetadata.SetAttributeValue(Saml2MetadataConstants.Message.ValidUntil, DateTimeOffset.UtcNow.AddDays(ValidUntil.Value).UtcDateTime.ToString(Schemas.Saml2Constants.DateTimeFormat, CultureInfo.InvariantCulture));
+                }
+                return singleDescriptorMetadata;
+            }
+            var multiDescriptorMetadata = new XElement(Saml2MetadataConstants.MetadataNamespaceX + nameof(EntitiesDescriptor));
+            multiDescriptorMetadata.Add(GetXContent());
+            return multiDescriptorMetadata;
+        }
+
+        protected IEnumerable<XObject> GetXContent()
+        {
+            yield return new XAttribute(Saml2MetadataConstants.MetadataNamespaceNameX, Saml2MetadataConstants.MetadataNamespace);
+            yield return new XAttribute(Saml2MetadataConstants.Message.Id, IdAsString);
+            if (ValidUntil.HasValue)
+            {
+                yield return new XAttribute(Saml2MetadataConstants.Message.ValidUntil, DateTimeOffset.UtcNow.AddDays(ValidUntil.Value).UtcDateTime.ToString(Schemas.Saml2Constants.DateTimeFormat, CultureInfo.InvariantCulture));
+            }
+            foreach (var entityDescriptor in EntitiesDescriptor)
+            {
+                yield return entityDescriptor.ToXElement();
+            }
         }
     }
 }

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/EntityDescriptor.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/EntityDescriptor.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -24,17 +23,15 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
     {
         const string elementName = Saml2MetadataConstants.Message.EntityDescriptor;
 
-        public Saml2Configuration Config { get; protected set; }
-
         /// <summary>
         /// Specifies the unique identifier of the SAML entity whose metadata is described by the element's contents.
         /// </summary>
-        public string EntityId { get; protected set; }
+        public string EntityId { get; set; }
 
         /// <summary>
         /// A document-unique identifier for the element, typically used as a reference point when signing.
         /// </summary>
-        public Saml2Id Id { get; protected set; }
+        public Saml2Id Id { get; set; } = new Saml2Id();
 
         /// <summary>
         /// The ID as string.
@@ -44,26 +41,6 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
         {
             get { return Id.Value; }
         }
-
-        /// <summary>
-        /// [Optional]
-        /// An metadata XML signature that authenticates the containing element and its contents.
-        /// </summary>
-        public X509Certificate2 MetadataSigningCertificate { get; protected set; }
-
-        /// <summary>
-        /// [Optional]
-        /// Default EndCertOnly (Only the end certificate is included in the X.509 chain information).
-        /// </summary>
-        public X509IncludeOption CertificateIncludeOption { get; set; }
-
-        /// <summary>
-        /// [Optional]
-        /// Optional attribute indicates the expiration time of the metadata contained in the element and any contained elements.
-        /// 
-        /// Metadata is valid until in days from now.
-        /// </summary>
-        public int? ValidUntil { get; set; }
 
         /// <summary>
         /// [Optional]
@@ -110,31 +87,11 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
         public EntityDescriptor()
         { }
 
-        public EntityDescriptor(Saml2Configuration config, bool signMetadata = true) : this()
-        {
-            if (config == null) throw new ArgumentNullException(nameof(config));
-
-            Config = config;
-            EntityId = config.Issuer;
-            Id = new Saml2Id();
-            if (signMetadata)
-            {
-                MetadataSigningCertificate = config.SigningCertificate;
-                CertificateIncludeOption = X509IncludeOption.EndCertOnly;
-            }
-        }
-
-        public XmlDocument ToXmlDocument()
+        public XElement ToXElement()
         {
             var envelope = new XElement(Saml2MetadataConstants.MetadataNamespaceX + elementName);
-
             envelope.Add(GetXContent());
-            var xmlDocument = envelope.ToXmlDocument();
-            if(MetadataSigningCertificate != null)
-            {
-                xmlDocument.SignDocument(MetadataSigningCertificate, Config.SignatureAlgorithm, Config.XmlCanonicalizationMethod, CertificateIncludeOption, IdAsString);
-            }
-            return xmlDocument;
+            return envelope;
         }
 
         protected IEnumerable<XObject> GetXContent()
@@ -145,11 +102,6 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
             }
             yield return new XAttribute(Saml2MetadataConstants.Message.EntityId, EntityId);
             yield return new XAttribute(Saml2MetadataConstants.Message.Id, IdAsString);
-            if (ValidUntil.HasValue)
-            {
-                yield return new XAttribute(Saml2MetadataConstants.Message.ValidUntil, DateTimeOffset.UtcNow.AddDays(ValidUntil.Value).UtcDateTime.ToString(Saml2Constants.DateTimeFormat, CultureInfo.InvariantCulture));
-            }
-            yield return new XAttribute(Saml2MetadataConstants.MetadataNamespaceNameX, Saml2MetadataConstants.MetadataNamespace);
 
             if (Extensions != null) 
             {


### PR DESCRIPTION
We're trying to use this library to connect to the [Dutch DigiD](https://www.digid.nl/en/).

However, their SAML [requires](https://www.dictu.nl/sites/default/files/2023-10/Koppelvlakspecificatie-eID-SAML-v4.4.pdf) more advanced configuration than this library supports, because it deals with three different types of entities, two of which end up in the metadata:

- The identity provider (the government agency). They read our metadata.
- The cluster connection provider (us). The first `EntityDescriptor` in the metadata.
- The service providers (two or more companies that offer services that they want to protect using DigiD login), the subsequent `EntityDescriptor`s in the metadata.

We've made our own internal alternative to `Saml2Configuration` that can store all the required information. However we needed to change the metadata XML generation to support the `EntitiesDescriptor` root element.

To do so, we moved the metadata specific logic from `EntityDescriptor` to `Saml2Metadata`, 