### PR TITLE
Allow nested assertions

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2ArtifactResponse.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2ArtifactResponse.cs
@@ -88,7 +88,7 @@ namespace ITfoxtec.Identity.Saml2
 
         private XmlElement GetAssertionElementReference()
         {
-            var assertionElements = GetInnerArtifactElementXml().SelectNodes($"//*[local-name()='{Schemas.Saml2Constants.Message.Assertion}']");
+            var assertionElements = GetInnerArtifactElementXml().SelectNodes($"//*[local-name()='{Schemas.Saml2Constants.Message.Assertion}']/ancestor-or-self::*[local-name()='{Schemas.Saml2Constants.Message.Assertion}'][last()]");
             if (assertionElements.Count != 1)
             {
                 throw new Saml2RequestException("There is not exactly one Assertion element in the inner Artifact element.");

--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnResponse.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2AuthnResponse.cs
@@ -286,7 +286,9 @@ namespace ITfoxtec.Identity.Saml2
 
         protected XmlElement GetAssertionElementReference()
         {
-            var assertionElements = XmlDocument.DocumentElement.SelectNodes($"//*[local-name()='{Schemas.Saml2Constants.Message.Assertion}']");
+            // Select all Assertion elements in the document that are at the top of their respective Assertion hierarchy.
+            // If the document contains <Assertion><Assertion></Assertion></Assertion> only the outer (hierarchical parent) Assertion is selected.
+            var assertionElements = XmlDocument.DocumentElement.SelectNodes($"//*[local-name()='{Schemas.Saml2Constants.Message.Assertion}']/ancestor-or-self::*[local-name()='{Schemas.Saml2Constants.Message.Assertion}'][last()]");
             if (assertionElements.Count != 1)
             {
                 throw new Saml2RequestException("There is not exactly one Assertion element. Maybe the response is encrypted (set the Saml2Configuration.DecryptionCertificate).");


### PR DESCRIPTION
We couldn't use the authentication response we got after Dutch digital identity sign in (DigiD) because of an overzealous validation.

It does not permit multiple assertions in the response. However we receive a valid response that contains a single assertion, which contains an advice, which contains another assertion.

I've updated the XPath expression so that it only selects assertions that are the top of their hierarchy for the check.

### Example of what is now permitted

```xml
<AuthnResponse>
  <Assertion>
    <Assertion />
  </Assertion>
</AuthnResponse>
```

### These are still not permitted

```xml
<AuthnResponse>
  <Assertion />
  <Assertion />
<AuthnResponse>
```

```xml
<AuthnResponse>
  <Assertion />
  <Foo>
    <Assertion />
  </Foo>
<AuthnResponse>