### PR TITLE
Added localization for ContactPerson

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/ContactPerson.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/ContactPerson.cs
@@ -12,9 +12,10 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
     {
         const string elementName = Saml2MetadataConstants.Message.ContactPerson;
 
-        public ContactPerson(ContactTypes contactType)
+        public ContactPerson(ContactTypes contactType, string locale = null)
         {
             ContactType = contactType;
+            Locale = locale;
         }
 
         /// <summary>
@@ -23,6 +24,12 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
         /// technical, support, administrative, billing, and other.
         /// </summary>
         public ContactTypes ContactType { get; protected set; }
+
+        /// <summary>
+        /// [Optional]
+        /// Specifies the localization of the ContactPerson.
+        /// </summary>
+        public string Locale { get; protected set; }
 
         /// <summary>
         /// [Optional]
@@ -67,6 +74,11 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
         protected IEnumerable<XObject> GetXContent()
         {
             yield return new XAttribute(Saml2MetadataConstants.Message.ContactType, ContactType.ToString().ToLowerInvariant());
+
+            if (Locale != null)
+            {
+                yield return new XAttribute(XNamespace.Xml + "lang", Locale);
+            }
 
             if (Company != null)
             {

--- a/test/TestIdPCore/Controllers/MetadataController.cs
+++ b/test/TestIdPCore/Controllers/MetadataController.cs
@@ -58,7 +58,7 @@ namespace TestWebApp.Controllers
             entityDescriptor.Organization = organization;
             entityDescriptor.ContactPersons = 
             [
-                new ContactPerson(ContactTypes.Administrative)
+                new ContactPerson(ContactTypes.Administrative, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some Given Name",
@@ -66,7 +66,7 @@ namespace TestWebApp.Controllers
                     EmailAddress = "some@some-domain.com",
                     TelephoneNumber = "11111111",
                 },
-                new ContactPerson(ContactTypes.Technical)
+                new ContactPerson(ContactTypes.Technical, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some tech Given Name",

--- a/test/TestWebApp/Controllers/MetadataController.cs
+++ b/test/TestWebApp/Controllers/MetadataController.cs
@@ -48,7 +48,7 @@ namespace TestWebApp.Controllers
                 },
             };
             entityDescriptor.ContactPersons = new[] { 
-                new ContactPerson(ContactTypes.Administrative)
+                new ContactPerson(ContactTypes.Administrative, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some Given Name",
@@ -56,7 +56,7 @@ namespace TestWebApp.Controllers
                     EmailAddress = "some@some-domain.com",
                     TelephoneNumber = "11111111",
                 },
-                new ContactPerson(ContactTypes.Technical)
+                new ContactPerson(ContactTypes.Technical, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some tech Given Name",

--- a/test/TestWebAppCore/Controllers/MetadataController.cs
+++ b/test/TestWebAppCore/Controllers/MetadataController.cs
@@ -58,7 +58,7 @@ namespace TestWebApp.Controllers
             entityDescriptor.Organization = organization;
             entityDescriptor.ContactPersons = 
             [
-                new ContactPerson(ContactTypes.Administrative)
+                new ContactPerson(ContactTypes.Administrative, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some Given Name",
@@ -66,7 +66,7 @@ namespace TestWebApp.Controllers
                     EmailAddress = "some@some-domain.com",
                     TelephoneNumber = "11111111",
                 },
-                new ContactPerson(ContactTypes.Technical)
+                new ContactPerson(ContactTypes.Technical, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some tech Given Name",

--- a/test/TestWebAppCoreAngularApi/Controllers/MetadataController.cs
+++ b/test/TestWebAppCoreAngularApi/Controllers/MetadataController.cs
@@ -53,7 +53,7 @@ namespace TestWebAppCoreAngularApi.Controllers
                 },
             };
             entityDescriptor.ContactPersons = new[] {
-                new ContactPerson(ContactTypes.Administrative)
+                new ContactPerson(ContactTypes.Administrative, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some Given Name",
@@ -61,7 +61,7 @@ namespace TestWebAppCoreAngularApi.Controllers
                     EmailAddress = "some@some-domain.com",
                     TelephoneNumber = "11111111",
                 },
-                new ContactPerson(ContactTypes.Technical)
+                new ContactPerson(ContactTypes.Technical, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some tech Given Name",

--- a/test/TestWebAppCoreArtifact/Controllers/MetadataController.cs
+++ b/test/TestWebAppCoreArtifact/Controllers/MetadataController.cs
@@ -53,7 +53,7 @@ namespace TestWebAppArtifact.Controllers
                 },
             };
             entityDescriptor.ContactPersons = new[] { 
-                new ContactPerson(ContactTypes.Administrative)
+                new ContactPerson(ContactTypes.Administrative, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some Given Name",
@@ -61,7 +61,7 @@ namespace TestWebAppArtifact.Controllers
                     EmailAddress = "some@some-domain.com",
                     TelephoneNumber = "11111111",
                 },
-                new ContactPerson(ContactTypes.Technical)
+                new ContactPerson(ContactTypes.Technical, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some tech Given Name",

--- a/test/TestWebAppCoreAzureKeyVault/Controllers/MetadataController.cs
+++ b/test/TestWebAppCoreAzureKeyVault/Controllers/MetadataController.cs
@@ -54,7 +54,7 @@ namespace TestWebApp.Controllers
                 },
             };
             entityDescriptor.ContactPersons = new[] {
-                new ContactPerson(ContactTypes.Administrative)
+                new ContactPerson(ContactTypes.Administrative, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some Given Name",
@@ -62,7 +62,7 @@ namespace TestWebApp.Controllers
                     EmailAddress = "some@some-domain.com",
                     TelephoneNumber = "11111111",
                 },
-                new ContactPerson(ContactTypes.Technical)
+                new ContactPerson(ContactTypes.Technical, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some tech Given Name",

--- a/test/TestWebAppCoreFramework/Controllers/MetadataController.cs
+++ b/test/TestWebAppCoreFramework/Controllers/MetadataController.cs
@@ -54,7 +54,7 @@ namespace TestWebApp.Controllers
                 },
             };
             entityDescriptor.ContactPersons = new[] {
-                new ContactPerson(ContactTypes.Administrative)
+                new ContactPerson(ContactTypes.Administrative, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some Given Name",
@@ -62,7 +62,7 @@ namespace TestWebApp.Controllers
                     EmailAddress = "some@some-domain.com",
                     TelephoneNumber = "11111111",
                 },
-                new ContactPerson(ContactTypes.Technical)
+                new ContactPerson(ContactTypes.Technical, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some tech Given Name",

--- a/test/TestWebAppCoreNemLogin3Sp/Controllers/MetadataController.cs
+++ b/test/TestWebAppCoreNemLogin3Sp/Controllers/MetadataController.cs
@@ -51,7 +51,7 @@ namespace TestWebApp.Controllers
             };
             entityDescriptor.SPSsoDescriptor.SetDefaultEncryptionMethods();
             entityDescriptor.ContactPersons = new[] { 
-                new ContactPerson(ContactTypes.Administrative)
+                new ContactPerson(ContactTypes.Administrative, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some Given Name",
@@ -59,7 +59,7 @@ namespace TestWebApp.Controllers
                     EmailAddress = "some@some-domain.com",
                     TelephoneNumber = "11111111",
                 },
-                new ContactPerson(ContactTypes.Technical)
+                new ContactPerson(ContactTypes.Technical, "en")
                 {
                     Company = "Some Company",
                     GivenName = "Some tech Given Name",


### PR DESCRIPTION
Added support for the lang attribute on ContactPerson to address warnings issued by the SAMBI validator when this attribute is missing.

You can verify this change using the SAMBI validator at https://validator.sambi.se/#/.