### PR TITLE
Remove local repeated namespace from `Scoping`, `IDPList` and `IDPEnt…

### DIFF
--- a/src/ITfoxtec.Identity.Saml2.Mvc/ITfoxtec.Identity.Saml2.Mvc.csproj
+++ b/src/ITfoxtec.Identity.Saml2.Mvc/ITfoxtec.Identity.Saml2.Mvc.csproj
@@ -26,10 +26,10 @@ Support the Danish NemLog-in 2 / OIOSAML 2 and NemLog-in 3 / OIOSAML 3.</Descrip
     <PackageTags>SAML SAML 2.0 SAML2.0 SAML2 SAML 2 SAML-P SAMLP SSO Identity Provider (IdP) and Relying Party (RP) Authentication Metadata OIOSAML OIOSAML 2 OIOSAML 3 NemLogin NemLog-in 2 NemLog-in 3 ASP.NET MVC</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageIconUrl>https://itfoxtec.com/favicon.ico</PackageIconUrl>
-    <AssemblyVersion>4.11.1</AssemblyVersion>
-    <FileVersion>4.11.1</FileVersion>
+    <AssemblyVersion>4.11.3</AssemblyVersion>
+    <FileVersion>4.11.3</FileVersion>
     <Copyright>Copyright © 2024</Copyright>
-    <Version>4.11.1</Version>
+    <Version>4.11.3</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ITfoxtec.SAML2.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/ITfoxtec.Identity.Saml2.MvcCore/ITfoxtec.Identity.Saml2.MvcCore.csproj
+++ b/src/ITfoxtec.Identity.Saml2.MvcCore/ITfoxtec.Identity.Saml2.MvcCore.csproj
@@ -29,10 +29,10 @@ Support the Danish NemLog-in 2 / OIOSAML 2 and NemLog-in 3 / OIOSAML 3.</Descrip
     <PackageTags>SAML SAML 2.0 SAML2.0 SAML2 SAML 2 SAML-P SAMLP SSO Identity Provider (IdP) Relying Party (RP) Authentication Metadata OIOSAML OIOSAML 2 OIOSAML 3 NemLogin NemLog-in 2 NemLog-in 3 ASP.NET MVC Core</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageIconUrl>https://itfoxtec.com/favicon.ico</PackageIconUrl>
-    <AssemblyVersion>4.11.1</AssemblyVersion>
-    <FileVersion>4.11.1</FileVersion>
+    <AssemblyVersion>4.11.3</AssemblyVersion>
+    <FileVersion>4.11.3</FileVersion>
     <Copyright>Copyright © 2024</Copyright>
-    <Version>4.11.1</Version>
+    <Version>4.11.3</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ITfoxtec.SAML2.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/ITfoxtec.Identity.Saml2/ITfoxtec.Identity.Saml2.csproj
+++ b/src/ITfoxtec.Identity.Saml2/ITfoxtec.Identity.Saml2.csproj
@@ -30,10 +30,10 @@ Support the Danish NemLog-in 2 / OIOSAML 2 and NemLog-in 3 / OIOSAML 3.</Descrip
     <PackageTags>SAML SAML 2.0 SAML2.0 SAML2 SAML 2 SAML-P SAMLP SSO Identity Provider (IdP) Relying Party (RP) Authentication Metadata OIOSAML OIOSAML 2 OIOSAML 3 NemLogin NemLog-in 2 NemLog-in 3</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageIconUrl>https://itfoxtec.com/favicon.ico</PackageIconUrl>
-    <AssemblyVersion>4.11.1</AssemblyVersion>
-    <FileVersion>4.11.1</FileVersion>
+    <AssemblyVersion>4.11.3</AssemblyVersion>
+    <FileVersion>4.11.3</FileVersion>
     <Copyright>Copyright © 2024</Copyright>
-    <Version>4.11.1</Version>
+    <Version>4.11.3</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ITfoxtec.SAML2.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/ITfoxtec.Identity.Saml2/Schemas/IDPEntry.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/IDPEntry.cs
@@ -40,9 +40,7 @@ namespace ITfoxtec.Identity.Saml2.Schemas
         }
 
          protected virtual IEnumerable<XObject> GetXContent()
-        {
-            yield return new XAttribute(Saml2Constants.ProtocolNamespaceNameX, Saml2Constants.ProtocolNamespaceX);
-
+         {
             if (ProviderID != null)
             {
                 yield return new XAttribute(Saml2Constants.Message.ProviderID, ProviderID);

--- a/src/ITfoxtec.Identity.Saml2/Schemas/IDPList.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/IDPList.cs
@@ -33,12 +33,10 @@ namespace ITfoxtec.Identity.Saml2.Schemas
         }
 
          protected virtual IEnumerable<XObject> GetXContent()
-        {
-            yield return new XAttribute(Saml2Constants.ProtocolNamespaceNameX, Saml2Constants.ProtocolNamespaceX);
-
+         {
             if (GetComplete != null)
             {
-                yield return new XAttribute(Saml2Constants.Message.GetComplete, GetComplete);
+                yield return new XElement(Saml2Constants.Message.GetComplete, GetComplete);
             }
 
             if (IDPEntry != null)

--- a/src/ITfoxtec.Identity.Saml2/Schemas/Scoping.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Scoping.cs
@@ -40,13 +40,11 @@ namespace ITfoxtec.Identity.Saml2.Schemas
 
         protected virtual IEnumerable<XObject> GetXContent()
         {
-            yield return new XAttribute(Saml2Constants.ProtocolNamespaceNameX, Saml2Constants.ProtocolNamespaceX);
-
             if (RequesterID != null)
             {
                 foreach (var item in RequesterID)
                 {
-                    yield return new XAttribute(Saml2Constants.Message.RequesterID, item);
+                    yield return new XElement(Saml2Constants.Message.RequesterID, item);
                 }
             }
 

--- a/src/ITfoxtec.Identity.Saml2/Util/GenericTypeConverter.cs
+++ b/src/ITfoxtec.Identity.Saml2/Util/GenericTypeConverter.cs
@@ -87,6 +87,13 @@ namespace ITfoxtec.Identity.Saml2.Util
                     Comparison = ConvertValue<AuthnContextComparisonTypes>(xmlNode.Attributes[Schemas.Saml2Constants.Message.Comparison]?.Value, xmlNode),
                 });
             }
+            else if (genericType == typeof(Scoping))
+            {
+                return GenericConvertValue<T, Scoping>(new Scoping
+                {
+                    RequesterID = GetAuthnContextClassRef(xmlNode.SelectNodes($"//*[local-name()='{Schemas.Saml2Constants.Message.RequesterID}']")),
+                });
+            }
             else
             {
                 throw new NotSupportedException($"Unable to convert element {genericType}.");

--- a/test/TestWebAppCore/Controllers/AuthController.cs
+++ b/test/TestWebAppCore/Controllers/AuthController.cs
@@ -45,6 +45,20 @@ namespace TestWebAppCore.Controllers
                 //    Comparison = AuthnContextComparisonTypes.Exact,
                 //    AuthnContextClassRef = new string[] { AuthnContextClassTypes.PasswordProtectedTransport.OriginalString },
                 //},
+                Scoping = new Scoping 
+                { 
+                    IDPList = new IDPList
+                    { 
+                        IDPEntry = [new IDPEntry 
+                        {
+                            ProviderID = "https://qaz.org",
+                            Name = "xxx",
+                            Loc = "https://wsx.org"
+                        }], 
+                        GetComplete = "xxx" 
+                    }, 
+                    RequesterID = ["https://xyz.org"] 
+                }
             }).ToActionResult();
         }
 


### PR DESCRIPTION
…ry`.

Resolve Scoping.RequesterID and IDPList.GetComplete not an element bug. Resolve scoping bug "Unable to convert element ITfoxtec.Identity.Saml2.Schemas.Scoping".