### PR TITLE
EntityDescriptor HttpClient bypass SSL checks for local self-signed certificates (DEBUG mode only)

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/EntityDescriptor.cs
+++ b/src/ITfoxtec.Identity.Saml2/Schemas/Metadata/EntityDescriptor.cs
@@ -321,6 +321,11 @@ namespace ITfoxtec.Identity.Saml2.Schemas.Metadata
         )
         {
 #endif
+
+#if DEBUG
+            // accept self-signed certificates for development purposes
+            ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => { return true; };
+#endif
             using (var response = cancellationToken.HasValue ? await httpClient.GetAsync(spMetadataUrl, cancellationToken.Value) : await httpClient.GetAsync(spMetadataUrl))
             {
                 // Handle the response


### PR DESCRIPTION
Allow EntityDescriptor HttpClient to fetch Metadata from IIS/IIS Express with self-signed certificate