### PR TITLE
The TestIdPCore sample applications issuer is changed to "urn:itfoxte…

### DIFF
--- a/test/TestIdPCore/appsettings.json
+++ b/test/TestIdPCore/appsettings.json
@@ -8,7 +8,7 @@
     }
   },
   "Saml2": {
-    "Issuer": "itfoxtec-testidpcore",
+    "Issuer": "urn:itfoxtec-testidpcore",
     "SingleSignOnDestination": "https://localhost:44305/Auth/Login",
     "SingleLogoutDestination": "https://localhost:44305/Auth/Logout",
     "ArtifactResolutionService": {


### PR DESCRIPTION
…c-testidpcore" to not cause errors in .NET Framework.