### PR TITLE
Allow ValidateXmlSignature overrider in inherited classes

### DIFF
--- a/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
+++ b/src/ITfoxtec.Identity.Saml2/Request/Saml2Request.cs
@@ -251,7 +251,7 @@ namespace ITfoxtec.Identity.Saml2
             }
         }
 
-        protected SignatureValidation ValidateXmlSignature(XmlElement xmlElement)
+        protected virtual SignatureValidation ValidateXmlSignature(XmlElement xmlElement)
         {
             var xmlSignatures = xmlElement.SelectNodes($"*[local-name()='{Schemas.Saml2Constants.Message.Signature}' and namespace-uri()='{SignedXml.XmlDsigNamespaceUrl}']");
             if (xmlSignatures.Count == 0)


### PR DESCRIPTION
Hello Anders :)
we have a specific requirement for validation of signature. I wonder if it will be fine to mark ValidateXmlSignature method as virtual, so we can just override it.

Regards,
Grzegorz