### PR TITLE
Allow for claims transformations to be async.

### DIFF
--- a/src/ITfoxtec.Identity.Saml2.MvcCore/Extensions/Saml2ResponseExtensions.cs
+++ b/src/ITfoxtec.Identity.Saml2.MvcCore/Extensions/Saml2ResponseExtensions.cs
@@ -14,7 +14,22 @@ namespace ITfoxtec.Identity.Saml2.MvcCore
         /// </summary>
         /// <param name="lifetime">The period from the current time during which the token is valid. Default use the security token valid to time.</param>
         /// <param name="isPersistent">If the IsPersistent property is true, the cookie is written as a persistent cookie. Persistent cookies remain valid after the browser is closed until they expire.</param>
-        public static async Task<ClaimsPrincipal> CreateSession(this Saml2AuthnResponse saml2AuthnResponse, HttpContext httpContext, TimeSpan? lifetime = null, bool isPersistent = false, Func<ClaimsPrincipal, ClaimsPrincipal> claimsTransform = null)
+        public static Task<ClaimsPrincipal> CreateSession(this Saml2AuthnResponse saml2AuthnResponse, HttpContext httpContext, TimeSpan? lifetime = null, bool isPersistent = false, Func<ClaimsPrincipal, ClaimsPrincipal> claimsTransform = null)
+        {
+            Func<ClaimsPrincipal, Task<ClaimsPrincipal>> asyncClaimsTransform = null;
+            if (claimsTransform != null)
+            {
+                asyncClaimsTransform = (ClaimsPrincipal principal) => Task.FromResult(claimsTransform(principal));
+            }
+            return CreateSession(saml2AuthnResponse, httpContext, lifetime, isPersistent, asyncClaimsTransform);
+        }
+
+        /// <summary>
+        /// Create a Claims Principal and a Federated Authentication Session for the authenticated user.
+        /// </summary>
+        /// <param name="lifetime">The period from the current time during which the token is valid. Default use the security token valid to time.</param>
+        /// <param name="isPersistent">If the IsPersistent property is true, the cookie is written as a persistent cookie. Persistent cookies remain valid after the browser is closed until they expire.</param>
+        public static async Task<ClaimsPrincipal> CreateSession(this Saml2AuthnResponse saml2AuthnResponse, HttpContext httpContext, TimeSpan? lifetime = null, bool isPersistent = false, Func<ClaimsPrincipal, Task<ClaimsPrincipal>> claimsTransform = null)
         {
             if (httpContext.User.Identity.IsAuthenticated)
             {
@@ -35,7 +50,7 @@ namespace ITfoxtec.Identity.Saml2.MvcCore
 
             if (claimsTransform != null)
             {
-                principal = claimsTransform(principal);
+                principal = await claimsTransform(principal);
             }
 
             await httpContext.SignInAsync(Saml2Constants.AuthenticationScheme, principal,


### PR DESCRIPTION
Small change to allow for the claimsTransform delegate to be async as part of the CreateSession() helper.

CreateSession itself is already an async function, so this is a pretty small lift, but in order to reduce duplication this does add an extra heap allocation when the old synchronous path is run. Since a SAML parsing and login already generate a ton of stuff of the heap, it didn't seem to be a huge deal.